### PR TITLE
Mcrf profile url replace

### DIFF
--- a/class-gf-civicrm-fields.php
+++ b/class-gf-civicrm-fields.php
@@ -368,7 +368,7 @@ class FieldsAddOn extends \GFAddOn
   }
 
   /**
-   * Add MCRF setting options to the WebHook Feed settings.
+   * Add CMRF setting options to the WebHook Feed settings.
    *
    * @param array  $feed_settings_fields   An array of feed settings fields which will be displayed on the Feed Settings edit view.
    * @param object $addon                  The current instance of the \GFAddon object which extends \GFFeedAddOn or \GFPaymentAddOn.
@@ -377,22 +377,22 @@ class FieldsAddOn extends \GFAddOn
   {
     if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
       $civicrm_section_settings             = array(
-        'title'   => esc_html__('CiviCRM MCRF Settings', 'gf-civicrm'),
+        'title'   => esc_html__('CiviCRM CMRF Settings', 'gf-civicrm'),
         'tooltip' => sprintf(
           '<h6>%s</h6> %s',
-          esc_html__('Options to override the MCRF options used for this WebHook', 'gf-civicrm'),
-          esc_html__('You can choose whether you would like to override merge tags from this WebHook with data from MCRF and specify which connector to use.', 'gf-civicrm')
+          esc_html__('Options to override the CMRF options used for this WebHook', 'gf-civicrm'),
+          esc_html__('You can choose whether you would like to override merge tags from this WebHook with data from CMRF and specify which connector to use.', 'gf-civicrm')
         ),
         'fields'  => array(),
       );
       $civicrm_section_settings['fields'][] = array(
         'type'        => 'checkbox',
-        'name'        => 'civicrm_use_mcrf',
+        'name'        => 'civicrm_use_cmrf',
         'description' => esc_html__('Whether to use the CiviCRM REST Connection Profile for this form.', 'gf-civicrm'),
         'choices'     => array(
           array(
             'label' => esc_html__('Use CiviCRM REST Connection Profile', 'gf-civicrm'),
-            'name'  => 'civicrm_use_mcrf',
+            'name'  => 'civicrm_use_cmrf',
           ),
         ),
         'onclick'     => "jQuery(this).parents('form').submit();",
@@ -407,7 +407,7 @@ class FieldsAddOn extends \GFAddOn
           'gf-civicrm'
         ),
         'dependency'  => array(
-          'field'  => 'civicrm_use_mcrf',
+          'field'  => 'civicrm_use_cmrf',
           'values' => array(1),
         ),
         'choices'     => $this->get_cmrf_profile_options(),
@@ -601,8 +601,8 @@ class FieldsAddOn extends \GFAddOn
    */
   public function webhooks_request_url($request_url, $feed, $entry, $form)
   {
-    $use_mcrf = rgars($feed, 'meta/civicrm_use_mcrf');
-    if (! empty($use_mcrf) && boolval($use_mcrf)) {
+    $use_cmrf = rgars($feed, 'meta/civicrm_use_cmrf');
+    if (! empty($use_cmrf) && boolval($use_cmrf)) {
       $profiles     = get_profiles();
       $profile_name = rgars($feed, 'meta/civicrm_rest_connection');
       if (isset($profiles[$profile_name])) {
@@ -614,21 +614,21 @@ class FieldsAddOn extends \GFAddOn
 
       // Make sure we in fact have a profile to set the url with.
       if (isset($profile) && is_array($profile)) {
-        $mcrf_url    = add_query_arg(
+        $cmrf_url    = add_query_arg(
           array(
             'key'     => $profile['site_key'],
             'api_key' => $profile['api_key'],
           ),
           $profile['url']
         );
-        $request_url = str_replace('{civicrm_mcrf_url}', $mcrf_url, $feed['meta']['requestURL']);
+        $request_url = str_replace('{civicrm_cmrf_url}', $cmrf_url, $feed['meta']['requestURL']);
       }
     }
     return $request_url;
   }
 
   /**
-   * Add merge tag for MCRF.
+   * Add merge tag for CMRF.
    *
    * @param array $merge_tags The current merge tags.
    * @return array
@@ -636,8 +636,8 @@ class FieldsAddOn extends \GFAddOn
   public function compose_merge_tags($merge_tags)
   {
     $merge_tags[] = array(
-      'label' => __('CiviCRM MCRF Url', 'gf-civicrm'),
-      'tag'   => '{civicrm_mcrf_url}',
+      'label' => __('CiviCRM CMRF Url', 'gf-civicrm'),
+      'tag'   => '{civicrm_cmrf_url}',
     );
 
     return $merge_tags;

--- a/class-gf-civicrm-fields.php
+++ b/class-gf-civicrm-fields.php
@@ -3,47 +3,50 @@
 namespace GFCiviCRM;
 
 use Civi\Api4\Contact;
-use GFForms,
-
-\GFAddon, \GFAPI;
+use GFForms;
+use GFAddon;
+use GFAPI;
 
 GFForms::include_addon_framework();
 
 class FieldsAddOn extends \GFAddOn
 {
-    protected $_version = GF_CIVICRM_FIELDS_ADDON_VERSION;
 
-    protected $_min_gravityforms_version = '1.9';
 
-    protected $_slug = 'gf-civicrm';
 
-    protected $_path = 'gf-civicrm/gf-civicrm.php';
+  protected $_version = GF_CIVICRM_FIELDS_ADDON_VERSION;
 
-    protected $_full_path = __FILE__;
+  protected $_min_gravityforms_version = '1.9';
 
-    protected $_title = 'Gravity Forms CiviCRM Add-On';
+  protected $_slug = 'gf-civicrm';
 
-    protected $_short_title = 'CiviCRM';
+  protected $_path = 'gf-civicrm/gf-civicrm.php';
 
-    private $gf_civicrm_address_field;
+  protected $_full_path = __FILE__;
+
+  protected $_title = 'Gravity Forms CiviCRM Add-On';
+
+  protected $_short_title = 'CiviCRM';
+
+  private $gf_civicrm_address_field;
 
   /**
    * @var \GFCiviCRM\FieldsAddOn $_instance If available, contains an instance of this class.
    */
-    private static $_instance = null;
+  private static $_instance = null;
 
   /**
-     * Class constructor which hooks the instance into the WordPress init action
-     */
-    function __construct()
-    {
-        parent::__construct();
+   * Class constructor which hooks the instance into the WordPress init action
+   */
+  function __construct()
+  {
+    parent::__construct();
 
     // Define capabilities in case role/permissions have been customised (e.g. Members plugin)
-        $this->_capabilities_settings_page  = 'gravityforms_edit_settings';
-        $this->_capabilities_form_settings  = 'gravityforms_edit_forms';
-        $this->_capabilities_uninstall      = 'gravityforms_uninstall';
-    }
+    $this->_capabilities_settings_page = 'gravityforms_edit_settings';
+    $this->_capabilities_form_settings = 'gravityforms_edit_forms';
+    $this->_capabilities_uninstall     = 'gravityforms_uninstall';
+  }
 
   /**
    * Returns an instance of this class, and stores it in the $_instance
@@ -51,161 +54,182 @@ class FieldsAddOn extends \GFAddOn
    *
    * @return \GFCiviCRM\FieldsAddOn $_instance An instance of this class.
    */
-    public static function get_instance()
-    {
-        if (self::$_instance == null) {
-            self::$_instance = new self();
-        }
-
-        return self::$_instance;
+  public static function get_instance()
+  {
+    if (self::$_instance == null) {
+      self::$_instance = new self();
     }
+
+    return self::$_instance;
+  }
 
   /**
    * Include the field early, so it is available when entry exports are being
    * performed.
    */
-    public function pre_init()
-    {
-        parent::pre_init();
+  public function pre_init()
+  {
+    parent::pre_init();
 
-      // Add the CiviCRM Group Contact Select field
-        if ($this->is_gravityforms_supported() && class_exists('GF_Field')) {
-            require_once('includes/class-gf-field-group-contact-select.php');
-            require_once('includes/class-civicrm-payment-token.php');
-        }
+    // Add the CiviCRM Group Contact Select field
+    if ($this->is_gravityforms_supported() && class_exists('GF_Field')) {
+      require_once 'includes/class-gf-field-group-contact-select.php';
+      require_once 'includes/class-civicrm-payment-token.php';
     }
 
-    public function init_admin()
-    {
-        parent::init_admin();
+    add_filter('gform_webhooks_request_url', array($this, 'webhooks_request_url'), 5, 4);
+  }
 
-      // Add the CiviCRM Group Contact Select field settings
-        add_action('gform_field_standard_settings', [
+  public function init_admin()
+  {
+    parent::init_admin();
+
+    // Add the CiviCRM Group Contact Select field settings
+    add_action(
+      'gform_field_standard_settings',
+      array(
         'GF_Field_Group_Contact_Select',
         'field_standard_settings',
-        ], 10, 2);
+      ),
+      10,
+      2
+    );
 
-        add_action('gform_field_standard_settings', [
+    add_action(
+      'gform_field_standard_settings',
+      array(
         'GFCiviCRM\CiviCRM_Payment_Token',
         'field_standard_settings',
-        ], 10, 2);
+      ),
+      10,
+      2
+    );
 
-      // Notify if CiviCRM Site Key and/or API Key is empty
-        add_action('admin_notices', function () {
-          // Only if CMRF is not active
-            if (!is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
-                $gf_civicrm_site_key = FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_site_key');
-                $gf_civicrm_api_key = FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_api_key');
-                $missing = [];
-                if (!$gf_civicrm_site_key) {
-                    $missing[] = 'Site Key';
-                }
-                if (!$gf_civicrm_api_key) {
-                    $missing[] = 'API Key';
-                }
-                if (!empty($missing)) {
-                    $this->warn_keys_settings($missing);
-                }
-            }
-        });
+    // Notify if CiviCRM Site Key and/or API Key is empty
+    add_action(
+      'admin_notices',
+      function () {
+        // Only if CMRF is not active
+        if (! is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+          $gf_civicrm_site_key = FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_site_key');
+          $gf_civicrm_api_key  = FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_api_key');
+          $missing             = array();
+          if (! $gf_civicrm_site_key) {
+            $missing[] = 'Site Key';
+          }
+          if (! $gf_civicrm_api_key) {
+            $missing[] = 'API Key';
+          }
+          if (! empty($missing)) {
+            $this->warn_keys_settings($missing);
+          }
+        }
+      }
+    );
 
-      // Notify the Webhook URL Merge Tags Replacer status
-        add_action('admin_notices', function () {
-            if (isset($_GET['subview']) && $_GET['subview'] === 'gf-civicrm') {
-                if (get_transient('gfcv_webhook_merge_tags_replacement_failure')) {
-                    $status_message = 'Something went wrong.';
-                    $notice_class = 'error';
-                } elseif (get_transient('gfcv_webhook_merge_tags_replacement_success')) {
-                    $status_message = 'Success!';
-                    $notice_class = 'success';
-                } else {
-                    return; // Do nothing if there are no statuses
-                }
+    // Notify the Webhook URL Merge Tags Replacer status
+    add_action(
+      'admin_notices',
+      function () {
+        if (isset($_GET['subview']) && $_GET['subview'] === 'gf-civicrm') {
+          if (get_transient('gfcv_webhook_merge_tags_replacement_failure')) {
+            $status_message = 'Something went wrong.';
+            $notice_class   = 'error';
+          } elseif (get_transient('gfcv_webhook_merge_tags_replacement_success')) {
+            $status_message = 'Success!';
+            $notice_class   = 'success';
+          } else {
+            return; // Do nothing if there are no statuses
+          }
 
-                $message = sprintf(
-                    '<p><strong>%1$s</strong></p><p>%2$s</p>',
-                    esc_html__('Executed Webhook URL Merge Tags Replacements.', 'gravityforms'),
-                    esc_html__($status_message, 'gravityforms'),
-                );
+          $message = sprintf(
+            '<p><strong>%1$s</strong></p><p>%2$s</p>',
+            esc_html__('Executed Webhook URL Merge Tags Replacements.', 'gravityforms'),
+            esc_html__($status_message, 'gravityforms'),
+          );
 
-                printf('<div class="notice notice-%s gf-notice" id="gform_status_notice">%s</div>', $notice_class, $message);
-            }
-        });
+          printf('<div class="notice notice-%s gf-notice" id="gform_status_notice">%s</div>', $notice_class, $message);
+        }
+      }
+    );
 
-        add_action('admin_init', [$this, 'maybe_run_merge_tags_replacer']);
+    add_action('admin_init', array($this, 'maybe_run_merge_tags_replacer'));
+
+    add_filter('gform_gravityformswebhooks_feed_settings_fields', array($this, 'webhook_feed_settings'), 10, 2);
+    add_filter('gform_custom_merge_tags', array($this, 'compose_merge_tags'), 10, 1);
+  }
+
+  public function maybe_run_merge_tags_replacer()
+  {
+    if (isset($_GET['gf_webhook_merge_tags_replacement_action']) && 'run' === $_GET['gf_webhook_merge_tags_replacement_action']) {
+      // Clear status messaging transients
+      delete_transient('gfcv_webhook_merge_tags_replacement_failure');
+      delete_transient('gfcv_webhook_merge_tags_replacement_success');
+
+      // Verify nonce for security.
+      if (! isset($_GET['gf_webhook_merge_tags_replacement_nonce']) || ! wp_verify_nonce($_GET['gf_webhook_merge_tags_replacement_nonce'], 'webhook_merge_tags_replacement_nonce')) {
+        wp_die(__('Security check failed', 'gf-civicrm'));
+      }
+
+      // Call the replacer function
+      $updater = Upgrader::get_instance();
+      $result  = $updater->execute_webhook_url_merge_tags_replacements();
+
+      if (! $result || empty($result)) {
+        set_transient('gfcv_webhook_merge_tags_replacement_failure', true, 60);
+      } else {
+        set_transient('gfcv_webhook_merge_tags_replacement_success', true, 60);
+      }
+
+      // Redirect back to the CiviCRM Settings page with a status message
+      wp_redirect(
+        add_query_arg(
+          array(
+            'page'    => 'gf_settings',
+            'subview' => 'gf-civicrm',
+          ),
+          admin_url('admin.php')
+        )
+      );
+      exit;
+    }
+  }
+
+  public function init()
+  {
+    parent::init();
+
+    if ($this->is_gravityforms_supported() && class_exists('GF_Field')) {
+      require_once 'includes/class-gf-civicrm-address-field.php';
+      $this->gf_civicrm_address_field = new Address_Field();
+    }
+  }
+
+  public function warn_auth_checksum($wrapper = '<div class="notice notice-warning is-dismissible">%s</div>')
+  {
+    $forms = GFAPI::get_forms();
+
+    $warnings = array();
+
+    foreach ($forms as $form) {
+      $settings = $this->get_form_settings($form);
+      if (! empty($settings['civicrm_auth_checksum'])) {
+        $settings_link = admin_url('admin.php?page=gf_edit_forms&view=settings&subview=gf-civicrm&id=' . $form['id']);
+        $warnings[]    = sprintf(__('The Gravity Form "%1$s" has the <strong>nonfunctional</strong> CiviCRM auth checksum setting enabled. <a href="%2$s">Click here to edit the form settings.</a>', 'text-domain'), esc_html($form['title']), esc_url($settings_link));
+      }
     }
 
-    public function maybe_run_merge_tags_replacer()
-    {
-        if (isset($_GET['gf_webhook_merge_tags_replacement_action']) && 'run' === $_GET['gf_webhook_merge_tags_replacement_action']) {
-          // Clear status messaging transients
-            delete_transient('gfcv_webhook_merge_tags_replacement_failure');
-            delete_transient('gfcv_webhook_merge_tags_replacement_success');
-
-          // Verify nonce for security.
-            if (! isset($_GET['gf_webhook_merge_tags_replacement_nonce']) || ! wp_verify_nonce($_GET['gf_webhook_merge_tags_replacement_nonce'], 'webhook_merge_tags_replacement_nonce')) {
-                wp_die(__('Security check failed', 'gf-civicrm'));
-            }
-
-          // Call the replacer function
-            $updater = Upgrader::get_instance();
-            $result = $updater->execute_webhook_url_merge_tags_replacements();
-
-            if (!$result || empty($result)) {
-                set_transient('gfcv_webhook_merge_tags_replacement_failure', true, 60);
-            } else {
-                set_transient('gfcv_webhook_merge_tags_replacement_success', true, 60);
-            }
-
-        // Redirect back to the CiviCRM Settings page with a status message
-            wp_redirect(
-                add_query_arg(
-                    [
-                    'page' => 'gf_settings',
-                    'subview' => 'gf-civicrm',
-                    ],
-                    admin_url('admin.php')
-                )
-            );
-            exit;
-        }
+    if (! empty($warnings)) {
+      $notice_heading = __('Legacy setting enabled for form(s)');
+      $notice_footer  = sprintf(
+        __('For details on setting up an alternative method for checksum authentication, see the README section on <a target="_blank" href="%1$s">Processing form submissions as a specific Contact</a>'),
+        'https://github.com/agileware/gf-civicrm/blob/main/README.md#processing-form-submissions-as-a-specific-contact'
+      );
+      return sprintf($wrapper, '<h3>' . $notice_heading . '</h3><ul>' . implode('', $warnings) . '</ul><p>' . $notice_footer . '</p>');
+    } else {
+      return null;
     }
-
-    public function init()
-    {
-        parent::init();
-
-        if ($this->is_gravityforms_supported() && class_exists('GF_Field')) {
-            require_once('includes/class-gf-civicrm-address-field.php');
-            $this->gf_civicrm_address_field = new Address_Field();
-        }
-    }
-
-    public function warn_auth_checksum($wrapper = '<div class="notice notice-warning is-dismissible">%s</div>')
-    {
-        $forms = GFAPI::get_forms();
-
-        $warnings = [];
-
-        foreach ($forms as $form) {
-            $settings = $this->get_form_settings($form);
-            if (!empty($settings['civicrm_auth_checksum'])) {
-                $settings_link = admin_url('admin.php?page=gf_edit_forms&view=settings&subview=gf-civicrm&id=' . $form['id']);
-                $warnings[] = sprintf(__('The Gravity Form "%s" has the <strong>nonfunctional</strong> CiviCRM auth checksum setting enabled. <a href="%s">Click here to edit the form settings.</a>', 'text-domain'), esc_html($form['title']), esc_url($settings_link));
-            }
-        }
-
-        if (!empty($warnings)) {
-            $notice_heading = __('Legacy setting enabled for form(s)');
-            $notice_footer  = sprintf(
-                __('For details on setting up an alternative method for checksum authentication, see the README section on <a target="_blank" href="%1$s">Processing form submissions as a specific Contact</a>'),
-                'https://github.com/agileware/gf-civicrm/blob/main/README.md#processing-form-submissions-as-a-specific-contact'
-            );
-            return sprintf($wrapper, '<h3>' . $notice_heading . '</h3><ul>' . implode('', $warnings) . '</ul><p>' . $notice_footer . '</p>');
-        } else {
-            return null;
-        }
-    }
+  }
 
   /**
    * Displays a warning if either or both of the CiviCRM Site Key and CiviCRM API Key settings are empty/null.
@@ -214,321 +238,401 @@ class FieldsAddOn extends \GFAddOn
    *
    * @param array $settings        The missing settings.
    */
-    public function warn_keys_settings($settings = [])
-    {
-        if (empty($settings)) {
-          // Do nothing. We don't know what we're warning against.
-            return;
-        }
-
-        $settings_text = implode(' and ', $settings);
-
-        $message = sprintf(
-            '<p><strong>%1$s%2$s%3$s</strong></p><p>%4$s</p>',
-            $settings_text,
-            count($settings) > 1 ? ' are' : ' is',
-            esc_html__(' missing in the Gravity Forms CiviCRM Settings.', 'gravityforms'),
-            esc_html__('These are required for the {gf_civicrm_site_key} and {gf_civicrm_api_key} merge tags. If you are using these, please check your configuration.', 'gravityforms'),
-        );
-
-        printf('<div class="notice notice-warning gf-notice" id="gform_warn_missing_keys_notice">%s</div>', $message);
+  public function warn_keys_settings($settings = array())
+  {
+    if (empty($settings)) {
+      // Do nothing. We don't know what we're warning against.
+      return;
     }
+
+    $settings_text = implode(' and ', $settings);
+
+    $message = sprintf(
+      '<p><strong>%1$s%2$s%3$s</strong></p><p>%4$s</p>',
+      $settings_text,
+      count($settings) > 1 ? ' are' : ' is',
+      esc_html__(' missing in the Gravity Forms CiviCRM Settings.', 'gravityforms'),
+      esc_html__('These are required for the {gf_civicrm_site_key} and {gf_civicrm_api_key} merge tags. If you are using these, please check your configuration.', 'gravityforms'),
+    );
+
+    printf('<div class="notice notice-warning gf-notice" id="gform_warn_missing_keys_notice">%s</div>', $message);
+  }
 
   /**
    * Include gf-civicrm-fields.js when the form contains a 'group_contact_select' type field.
    *
    * @return array
    */
-    public function scripts()
-    {
-        $scripts = [
-        [
+  public function scripts()
+  {
+    $scripts = array(
+      array(
         'handle'  => 'gf_civicrm_fields_js',
         'src'     => $this->get_base_url() . '/js/gf-civicrm-fields.js',
         'version' => $this->_version,
-        'deps'    => ['jquery'],
-        'enqueue' => [
-          [ 'field_types' => ['group_contact_select', 'civicrm_payment_token', 'address'] ],
-        ],
-        ],
-        [
+        'deps'    => array('jquery'),
+        'enqueue' => array(
+          array('field_types' => array('group_contact_select', 'civicrm_payment_token', 'address')),
+        ),
+      ),
+      array(
         'handle'    => 'gf_civicrm_address_fields',
         'src'       => $this->get_base_url() . '/js/gf-civicrm-address-fields.js',
         'version'   => $this->_version,
-        'deps'      => ['jquery', 'wp-util'],
+        'deps'      => array('jquery', 'wp-util'),
         'in_footer' => true,
-        'enqueue'   => [
-              [ $this->gf_civicrm_address_field, 'applyGFCiviCRMAddressField' ]
-        ],
-        ],
-        ];
+        'enqueue'   => array(
+          array($this->gf_civicrm_address_field, 'applyGFCiviCRMAddressField'),
+        ),
+      ),
+    );
 
-        return array_merge(parent::scripts(), $scripts);
-    }
+    return array_merge(parent::scripts(), $scripts);
+  }
 
   /**
    * Include gf-civicrm-fields.css when the form contains a 'group_contact_select' type field.
    *
    * @return array
    */
-    public function styles()
-    {
-        $styles = [
-        [
+  public function styles()
+  {
+    $styles = array(
+      array(
         'handle'  => 'gf_civicrm_fields_css',
         'src'     => $this->get_base_url() . '/css/gf-civicrm-fields.css',
         'version' => $this->_version,
-        'enqueue' => [
-          ['field_types' => ['group_contact_select', 'civicrm_payment_token']],
-        ],
-        ],
-        ];
+        'enqueue' => array(
+          array('field_types' => array('group_contact_select', 'civicrm_payment_token')),
+        ),
+      ),
+    );
 
-        return array_merge(parent::styles(), $styles);
-    }
+    return array_merge(parent::styles(), $styles);
+  }
 
   /**
    * Add form settings tab, *only if* legacy settings are already set.
    */
-    public function add_form_settings_menu($tabs, $form_id)
-    {
-        $settings = $this->get_form_settings($form_id);
+  public function add_form_settings_menu($tabs, $form_id)
+  {
+    $settings = $this->get_form_settings($form_id);
 
-        if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
-            $tabs[] = array (
-            'name' => $this->get_slug(),
-            'label' => 'CiviCRM MCRF',
-            'icon' => 'gform-icon--cog',
-            'query' => array (
-            'cid' => null,
-            'nid' => null,
-            'fid' => null,
-            ),
-            'capabilities' => array (
-            0 => 'gravityforms_edit_forms',
-            ),
-            );
-        }
+    if (! empty($settings['civicrm_auth_checksum'])) {
+      return parent::add_form_settings_menu($tabs, $form_id);
+    } else {
+      return $tabs;
+    }
+  }
 
-        if (! empty($settings['civicrm_auth_checksum'])) {
-            return parent::add_form_settings_menu($tabs, $form_id);
-        } else {
-            return $tabs;
-        }
+  public function form_settings_fields($form)
+  {
+    $settings = $this->get_form_settings($form) ?: array();
+
+    $fields = array();
+
+    // Legacy field, don't allow for new forms.
+    if (! empty($settings['civicrm_auth_checksum'])) {
+      $fields[] = array(
+        'type'        => 'checkbox',
+        'name'        => 'civicrm_auth_checksum',
+        'description' => wp_kses(
+          sprintf(
+            __(
+              '<strong>Nonfunctional</strong>: This option is no longer functional due to a <strong>security risk</strong>. Switch to the replacement workflow using Form Processor capabilities outlined <a target="_blank" href="%s">in the README</a>.',
+              'gf-civicrm'
+            ),
+            'https://github.com/agileware/gf-civicrm/tree/main?tab=readme-ov-file#processing-form-submissions-as-a-specific-contact'
+          ),
+          'data'
+        ),
+        'choices'     => array(
+          array(
+            'label' => esc_html__('Allow authentication with checksum', 'gf-civicrm'),
+            'name'  => 'civicrm_auth_checksum',
+          ),
+        ),
+      );
     }
 
-    public function form_settings_fields($form)
-    {
-        $settings = $this->get_form_settings($form) ?: [];
-
-        $fields = [];
-        $fields[] = [
-          'type'        => 'checkbox',
-          'name'        => 'civicrm_use_mcrf',
-          'description' => esc_html__('Whether to use the CiviCRM REST Connection Profile for this form.', 'gf-civicrm'),
-          'choices'     => [
-            [
-              'label' => esc_html__('Use CiviCRM REST Connection Profile', 'gf-civicrm'),
-              'name'  => 'civicrm_use_mcrf'
-            ]
-          ]
-        ];
-
-        // Legacy field, don't allow for new forms.
-        if (! empty($settings['civicrm_auth_checksum'])) {
-            $fields[] = [
-                'type'        => 'checkbox',
-                'name'        => 'civicrm_auth_checksum',
-                'description' => wp_kses(sprintf(__(
-                    '<strong>Nonfunctional</strong>: This option is no longer functional due to a <strong>security risk</strong>. Switch to the replacement workflow using Form Processor capabilities outlined <a target="_blank" href="%s">in the README</a>.',
-                    'gf-civicrm'
-                ), 'https://github.com/agileware/gf-civicrm/tree/main?tab=readme-ov-file#processing-form-submissions-as-a-specific-contact'), 'data'),
-                'choices'     => [
-                    [
-                        'label' => esc_html__('Allow authentication with checksum', 'gf-civicrm'),
-                        'name'  => 'civicrm_auth_checksum'
-                    ]
-                ]
-            ];
-        }
-
-        if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
-          // CiviCRM McRestFace
-            $fields[] = [
-            'label' => esc_html__('CiviCRM REST Connection Profile', 'gf-civicrm'),
-            'type'        => 'select',
-            'name'        => 'civicrm_rest_connection',
-            'description' => esc_html__(
-                'Select which CMRF connection profile to use for this form.',
-                'gf-civicrm'
-            ),
-            'dependency' => array( 'field' => 'civicrm_use_mcrf', 'values' => array( 1 ) ),
-            'choices'     => $this->get_cmrf_profile_options()
-            ];
-        }
-
-        if (!empty($fields)) {
-            return [
-                [
-                    'title'  => esc_html__('CiviCRM Settings', 'gf-civicrm'),
-                    'fields' => &$fields,
-                ],
-            ];
-        } else {
-            return [];
-        }
+    if (! empty($fields)) {
+      return array(
+        array(
+          'title'  => esc_html__('CiviCRM Settings', 'gf-civicrm'),
+          'fields' => &$fields,
+        ),
+      );
+    } else {
+      return array();
     }
+  }
 
-    public function plugin_settings_fields()
-    {
-        $nonce = wp_create_nonce('webhook_merge_tags_replacement_nonce');
-        $action_url = add_query_arg(array(
+  /**
+   * Add MCRF setting options to the WebHook Feed settings.
+   *
+   * @param array  $feed_settings_fields   An array of feed settings fields which will be displayed on the Feed Settings edit view.
+   * @param object $addon                  The current instance of the \GFAddon object which extends \GFFeedAddOn or \GFPaymentAddOn.
+   */
+  public function webhook_feed_settings($feed_settings_fields, $addon)
+  {
+    if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+      $civicrm_section_settings             = array(
+        'title'   => esc_html__('CiviCRM MCRF Settings', 'gf-civicrm'),
+        'tooltip' => sprintf(
+          '<h6>%s</h6> %s',
+          esc_html__('Options to override the MCRF options used for this WebHook', 'gf-civicrm'),
+          esc_html__('You can choose whether you would like to override merge tags from this WebHook with data from MCRF and specify which connector to use.', 'gf-civicrm')
+        ),
+        'fields'  => array(),
+      );
+      $civicrm_section_settings['fields'][] = array(
+        'type'        => 'checkbox',
+        'name'        => 'civicrm_use_mcrf',
+        'description' => esc_html__('Whether to use the CiviCRM REST Connection Profile for this form.', 'gf-civicrm'),
+        'choices'     => array(
+          array(
+            'label' => esc_html__('Use CiviCRM REST Connection Profile', 'gf-civicrm'),
+            'name'  => 'civicrm_use_mcrf',
+          ),
+        ),
+        'onclick'     => "jQuery(this).parents('form').submit();",
+      );
+      // CiviCRM McRestFace
+      $civicrm_section_settings['fields'][] = array(
+        'label'       => esc_html__('CiviCRM REST Connection Profile', 'gf-civicrm'),
+        'type'        => 'select',
+        'name'        => 'civicrm_rest_connection',
+        'description' => esc_html__(
+          'Select which CMRF connection profile to use for this form.',
+          'gf-civicrm'
+        ),
+        'dependency'  => array(
+          'field'  => 'civicrm_use_mcrf',
+          'values' => array(1),
+        ),
+        'choices'     => $this->get_cmrf_profile_options(),
+      );
+      $feed_settings_fields                 = array_merge($feed_settings_fields, array($civicrm_section_settings));
+    }
+    return $feed_settings_fields;
+  }
+
+  public function plugin_settings_fields()
+  {
+    $nonce      = wp_create_nonce('webhook_merge_tags_replacement_nonce');
+    $action_url = add_query_arg(
+      array(
         'gf_webhook_merge_tags_replacement_action' => 'run',
         'gf_webhook_merge_tags_replacement_nonce'  => $nonce,
-        ), admin_url('admin.php?page=gf_settings&subview=gf-civicrm'));
+      ),
+      admin_url('admin.php?page=gf_settings&subview=gf-civicrm')
+    );
 
-        $fields = [];
+    $fields = array();
 
-        $fields[] = [
-        'title'       => esc_html__('CiviCRM Settings', 'gf-civicrm'),
-        'description' => esc_html__('Global settings for CiviCRM add-on', 'gf-civicrm'),
-        'fields'      => [
-        [
+    $fields[] = array(
+      'title'       => esc_html__('CiviCRM Settings', 'gf-civicrm'),
+      'description' => esc_html__('Global settings for CiviCRM add-on', 'gf-civicrm'),
+      'fields'      => array(
+        array(
           'type'          => 'checkbox',
           'name'          => 'gf_civicrm_flags',
-          'default_value' => [ 'civicrm_multi_json' ],
-          'choices' => [
-            [
-              'label'   => esc_html__('Use JSON encoding for Checkbox and Multiselect values in webhooks (recommended)', 'gf_civicrm'),
-              'name'    => 'civicrm_multi_json',
-            ],
-            [
+          'default_value' => array('civicrm_multi_json'),
+          'choices'       => array(
+            array(
+              'label' => esc_html__('Use JSON encoding for Checkbox and Multiselect values in webhooks (recommended)', 'gf_civicrm'),
+              'name'  => 'civicrm_multi_json',
+            ),
+            array(
               'label'   => esc_html__('Enable pre-releases for updates.', 'gf_civicrm'),
               'name'    => 'enable_prereleases',
               'tooltip' => esc_html__('Opt-in to including pre-releases/beta releases for GF CiviCRM updates. Please note that pre-releases may be unstable, so make sure to take a backup of your database before performing updates with this option enabled.', 'simpleaddon'),
-            ],
-          ],
-        ],
-        ],
-        ];
+            ),
+          ),
+        ),
+      ),
+    );
 
-        if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
-            $fields[] = [ // CiviCRM McRestFace or Local
-            'title'         => esc_html__('CiviCRM REST Connection Profile', 'gf-civicrm'),
-            'description'   => wp_kses_post(sprintf(
-                __('Select which CMRF connection profile to use for this form. <a href="%s">Configure connection profiles here.</a>', 'gf-civicrm'),
-                esc_url(add_query_arg([ 'page' => 'wpcmrf_admin' ], admin_url('options-general.php')))
-            )),
-            'fields'        => [ [
-              'type'          => 'select',
-              'name'          => 'civicrm_rest_connection',
-              'choices'       => $this->get_cmrf_profile_options(true),
-            ] ],
-            ];
-        }
+    if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+      $fields[] = array( // CiviCRM McRestFace or Local
+        'title'       => esc_html__('CiviCRM REST Connection Profile', 'gf-civicrm'),
+        'description' => wp_kses_post(
+          sprintf(
+            __('Select which CMRF connection profile to use for this form. <a href="%s">Configure connection profiles here.</a>', 'gf-civicrm'),
+            esc_url(add_query_arg(array('page' => 'wpcmrf_admin'), admin_url('options-general.php')))
+          )
+        ),
+        'fields'      => array(
+          array(
+            'type'    => 'select',
+            'name'    => 'civicrm_rest_connection',
+            'choices' => $this->get_cmrf_profile_options(true),
+          ),
+        ),
+      );
+    }
 
     // Only use these fields if CMRF is not active.
-        if (!is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
-            $fields[] = [
-            'title'       => esc_html__('CiviCRM Site Key', 'gf-civicrm'),
-            'description' => esc_html__('Provide the CiviCRM site key for making API calls, can be output using the merge tag {gf_civicrm_site_key}.', 'gf-civicrm'),
-            'fields'      => [ [
-              'type'          => 'text',
-              'name'          => 'gf_civicrm_site_key',
-              'default_value' => '',
-            ] ],
-            ];
+    if (! is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+      $fields[] = array(
+        'title'       => esc_html__('CiviCRM Site Key', 'gf-civicrm'),
+        'description' => esc_html__('Provide the CiviCRM site key for making API calls, can be output using the merge tag {gf_civicrm_site_key}.', 'gf-civicrm'),
+        'fields'      => array(
+          array(
+            'type'          => 'text',
+            'name'          => 'gf_civicrm_site_key',
+            'default_value' => '',
+          ),
+        ),
+      );
 
-            $fields[] = [
-            'title'       => esc_html__('CiviCRM API Key', 'gf-civicrm'),
-            'description' => esc_html__('Provide the CiviCRM API key for making API calls, can be output using the merge tag {gf_civicrm_api_key}.', 'gf-civicrm'),
-            'fields'      => [ [
+      $fields[] = array(
+        'title'       => esc_html__('CiviCRM API Key', 'gf-civicrm'),
+        'description' => esc_html__('Provide the CiviCRM API key for making API calls, can be output using the merge tag {gf_civicrm_api_key}.', 'gf-civicrm'),
+        'fields'      => array(
+          array(
             'type'          => 'text',
             'name'          => 'gf_civicrm_api_key',
             'default_value' => '',
-            ] ],
-            ];
-        }
-
-        $fields[] = [
-        'title'       => esc_html__('Webhook Alerts', 'gf-civicrm'),
-        'description' => nl2br(esc_html__("Webhook alerts will be sent to the email provided below.", 'gf-civicrm')),
-        'fields'      => [ [
-        'type'          => 'checkbox',
-        'name'          => 'gf_civicrm_alerts',
-        'choices' => [
-          [
-            'label'   => esc_html__('Enable email alerts', 'gf_civicrm'),
-            'name'    => 'enable_emails',
-            'default_value' => true,
-          ],
-        ],
-        ],
-        [
-        'type'          => 'text',
-        'name'          => 'gf_civicrm_alerts_email',
-        'default_value' => '',
-        'validation_callback' => function ($field, $value) {
-          // Validate the value is actually an email
-            if (! is_email(trim($value))) {
-                $field->set_error(__('Please enter a valid email address.', 'gravityforms'));
-            }
-        }
-        ] ],
-        ];
-
-        $fields[] = [
-        'title'       => esc_html__('Import/Export Directory', 'gf-civicrm'),
-        'description' => nl2br(esc_html__("Define the path to the import/export directory, relative to the server document root. Used by Export GF CiviCRM and Import GF CiviCRM.\n\nYou can modify the subdirectories using the 'gf-civicrm/export-directory' and 'gf-civicrm/fp-export-directory' filters.", 'gf-civicrm')),
-        'fields'      => [ [
-        'type'          => 'text',
-        'name'          => 'gf_civicrm_import_export_directory',
-        'default_value' => 'CRM/gf-civicrm-exports',
-        ] ],
-        ];
-
-        $fields[] = [
-        'title'       => esc_html__('Webhook URL Merge Tags Replacements', 'gf-civicrm'),
-        'description' => __('Replaces the REST API url, and CiviCRM Site keys and API keys in Gravity Forms webhook request URLs with their equivalent merge tags, for all webhooks feeds. Saves the CiviCRM Site Key and API key in the settings.<br /><br /><strong>CAUTION:</strong> It is recommended to take a backup before running this function.', 'gf-civicrm'),
-        'fields'      => [ [
-        'name'  => 'webhook_merge_tags_replacer',
-        'label' => '',
-        'type'  => 'html',
-        'html'  => '<a href="' . esc_url($action_url) . '" class="button">Replace the Merge Tags</a>',
-        ] ],
-        ];
-
-        return $fields;
+          ),
+        ),
+      );
     }
+
+    $fields[] = array(
+      'title'       => esc_html__('Webhook Alerts', 'gf-civicrm'),
+      'description' => nl2br(esc_html__('Webhook alerts will be sent to the email provided below.', 'gf-civicrm')),
+      'fields'      => array(
+        array(
+          'type'    => 'checkbox',
+          'name'    => 'gf_civicrm_alerts',
+          'choices' => array(
+            array(
+              'label'         => esc_html__('Enable email alerts', 'gf_civicrm'),
+              'name'          => 'enable_emails',
+              'default_value' => true,
+            ),
+          ),
+        ),
+        array(
+          'type'                => 'text',
+          'name'                => 'gf_civicrm_alerts_email',
+          'default_value'       => '',
+          'validation_callback' => function ($field, $value) {
+            // Validate the value is actually an email
+            if (! is_email(trim($value))) {
+              $field->set_error(__('Please enter a valid email address.', 'gravityforms'));
+            }
+          },
+        ),
+      ),
+    );
+
+    $fields[] = array(
+      'title'       => esc_html__('Import/Export Directory', 'gf-civicrm'),
+      'description' => nl2br(esc_html__("Define the path to the import/export directory, relative to the server document root. Used by Export GF CiviCRM and Import GF CiviCRM.\n\nYou can modify the subdirectories using the 'gf-civicrm/export-directory' and 'gf-civicrm/fp-export-directory' filters.", 'gf-civicrm')),
+      'fields'      => array(
+        array(
+          'type'          => 'text',
+          'name'          => 'gf_civicrm_import_export_directory',
+          'default_value' => 'CRM/gf-civicrm-exports',
+        ),
+      ),
+    );
+
+    $fields[] = array(
+      'title'       => esc_html__('Webhook URL Merge Tags Replacements', 'gf-civicrm'),
+      'description' => __('Replaces the REST API url, and CiviCRM Site keys and API keys in Gravity Forms webhook request URLs with their equivalent merge tags, for all webhooks feeds. Saves the CiviCRM Site Key and API key in the settings.<br /><br /><strong>CAUTION:</strong> It is recommended to take a backup before running this function.', 'gf-civicrm'),
+      'fields'      => array(
+        array(
+          'name'  => 'webhook_merge_tags_replacer',
+          'label' => '',
+          'type'  => 'html',
+          'html'  => '<a href="' . esc_url($action_url) . '" class="button">Replace the Merge Tags</a>',
+        ),
+      ),
+    );
+
+    return $fields;
+  }
 
   /**
-     * Build choices for selectiing CMRF connection profiles on a global or per-form basis.
-     */
-    public function get_cmrf_profile_options($is_global = false)
-    {
-        $options = [];
+   * Build choices for selectiing CMRF connection profiles on a global or per-form basis.
+   */
+  public function get_cmrf_profile_options($is_global = false)
+  {
+    $options = array();
 
-        // Null or Default options
-        if ($is_global) {
-            $options[] = [
-                'label' => esc_html__("None", 'gf_civicrm'),
-                'value' => ""
-            ];
-        } else {
-            $options[] = [
-                'label' => esc_html__("Default", 'gf_civicrm'),
-                'value' => "default"
-            ];
-        }
-
-        $profiles = get_profiles();
-        foreach ($profiles as $profile_id => $profile) {
-            $options[] = [
-                'label' => esc_html__($profile['title'], 'gf_civicrm'),
-                'value' => $profile_id
-            ];
-        }
-
-        return $options;
+    // Null or Default options
+    if ($is_global) {
+      $options[] = array(
+        'label' => esc_html__('None', 'gf_civicrm'),
+        'value' => '',
+      );
+    } else {
+      $options[] = array(
+        'label' => esc_html__('Default', 'gf_civicrm'),
+        'value' => 'default',
+      );
     }
+
+    $profiles = get_profiles();
+    foreach ($profiles as $profile_id => $profile) {
+      $options[] = array(
+        'label' => esc_html__($profile['title'], 'gf_civicrm'),
+        'value' => $profile_id,
+      );
+    }
+
+    return $options;
+  }
+
+  /**
+   * Attempt to replace tags before feeds are processed.
+   *
+   * @since 2.0
+   *
+   * @param string      $requestUrl The url of the current feed being processed.
+   * @param false|array $feed  The current feed to be processed
+   * @param array       $entry Current entry for which feeds will be processed
+   * @param array       $form  Current form object.
+   *
+   * @return array An array of $feeds
+   */
+  public function webhooks_request_url($request_url, $feed, $entry, $form)
+  {
+    $use_mcrf = rgars($feed, 'meta/civicrm_use_mcrf');
+    if (! empty($use_mcrf) && boolval($use_mcrf)) {
+      $profiles     = get_profiles();
+      $profile_name = rgars($feed, 'meta/civicrm_rest_connection');
+      if (isset($profiles[$profile_name])) {
+        $profile     = $profiles[$profile_name];
+        $mcrf_url    = add_query_arg(
+          array(
+            'key'     => $profile['site_key'],
+            'api_key' => $profile['api_key'],
+          ),
+          $profile['url']
+        );
+        $request_url = str_replace('{civicrm_mcrf_url}', $mcrf_url, $feed['meta']['requestURL']);
+      }
+    }
+    return $request_url;
+  }
+
+  /**
+   * Add merge tag for MCRF.
+   *
+   * @param array $merge_tags The current merge tags.
+   * @return array
+   */
+  public function compose_merge_tags($merge_tags)
+  {
+    $merge_tags[] = array(
+      'label' => __('CiviCRM MCRF Url', 'gf-civicrm'),
+      'tag'   => '{civicrm_mcrf_url}',
+    );
+
+    return $merge_tags;
+  }
 }

--- a/class-gf-civicrm-fields.php
+++ b/class-gf-civicrm-fields.php
@@ -607,6 +607,13 @@ class FieldsAddOn extends \GFAddOn
       $profile_name = rgars($feed, 'meta/civicrm_rest_connection');
       if (isset($profiles[$profile_name])) {
         $profile     = $profiles[$profile_name];
+      } else if ( is_null( $profile_name ) || $profile_name === "default" ) {
+        // Fallback to default setting or first profile setup.
+        $profile = get_rest_connection_profile();
+      }
+
+      // Make sure we in fact have a profile to set the url with.
+      if (isset($profile) && is_array($profile)) {
         $mcrf_url    = add_query_arg(
           array(
             'key'     => $profile['site_key'],

--- a/class-gf-civicrm-fields.php
+++ b/class-gf-civicrm-fields.php
@@ -3,44 +3,47 @@
 namespace GFCiviCRM;
 
 use Civi\Api4\Contact;
-use GFForms, GFAddon, GFAPI;
+use GFForms,
+
+\GFAddon, \GFAPI;
 
 GFForms::include_addon_framework();
 
-class FieldsAddOn extends GFAddOn {
+class FieldsAddOn extends \GFAddOn
+{
+    protected $_version = GF_CIVICRM_FIELDS_ADDON_VERSION;
 
-  protected $_version = GF_CIVICRM_FIELDS_ADDON_VERSION;
+    protected $_min_gravityforms_version = '1.9';
 
-  protected $_min_gravityforms_version = '1.9';
+    protected $_slug = 'gf-civicrm';
 
-  protected $_slug = 'gf-civicrm';
+    protected $_path = 'gf-civicrm/gf-civicrm.php';
 
-  protected $_path = 'gf-civicrm/gf-civicrm.php';
+    protected $_full_path = __FILE__;
 
-  protected $_full_path = __FILE__;
+    protected $_title = 'Gravity Forms CiviCRM Add-On';
 
-  protected $_title = 'Gravity Forms CiviCRM Add-On';
+    protected $_short_title = 'CiviCRM';
 
-  protected $_short_title = 'CiviCRM';
-
-  private $gf_civicrm_address_field;
+    private $gf_civicrm_address_field;
 
   /**
    * @var \GFCiviCRM\FieldsAddOn $_instance If available, contains an instance of this class.
    */
-  private static $_instance = NULL;
+    private static $_instance = null;
 
   /**
-	 * Class constructor which hooks the instance into the WordPress init action
-	 */
-	function __construct() {
-		parent::__construct();
+     * Class constructor which hooks the instance into the WordPress init action
+     */
+    function __construct()
+    {
+        parent::__construct();
 
     // Define capabilities in case role/permissions have been customised (e.g. Members plugin)
-		$this->_capabilities_settings_page	= 'gravityforms_edit_settings';
-		$this->_capabilities_form_settings	= 'gravityforms_edit_forms';
-		$this->_capabilities_uninstall		= 'gravityforms_uninstall';
-	}
+        $this->_capabilities_settings_page  = 'gravityforms_edit_settings';
+        $this->_capabilities_form_settings  = 'gravityforms_edit_forms';
+        $this->_capabilities_uninstall      = 'gravityforms_uninstall';
+    }
 
   /**
    * Returns an instance of this class, and stores it in the $_instance
@@ -48,190 +51,198 @@ class FieldsAddOn extends GFAddOn {
    *
    * @return \GFCiviCRM\FieldsAddOn $_instance An instance of this class.
    */
-  public static function get_instance() {
-    if (self::$_instance == NULL) {
-      self::$_instance = new self();
-    }
+    public static function get_instance()
+    {
+        if (self::$_instance == null) {
+            self::$_instance = new self();
+        }
 
-    return self::$_instance;
-  }
+        return self::$_instance;
+    }
 
   /**
    * Include the field early, so it is available when entry exports are being
    * performed.
    */
-  public function pre_init() {
-    parent::pre_init();
+    public function pre_init()
+    {
+        parent::pre_init();
 
-    // Add the CiviCRM Group Contact Select field
-    if ($this->is_gravityforms_supported() && class_exists('GF_Field')) {
-      require_once('includes/class-gf-field-group-contact-select.php');
-      require_once('includes/class-civicrm-payment-token.php');
+      // Add the CiviCRM Group Contact Select field
+        if ($this->is_gravityforms_supported() && class_exists('GF_Field')) {
+            require_once('includes/class-gf-field-group-contact-select.php');
+            require_once('includes/class-civicrm-payment-token.php');
+        }
     }
-  }
 
-  public function init_admin() {
-    parent::init_admin();
+    public function init_admin()
+    {
+        parent::init_admin();
 
-    // Add the CiviCRM Group Contact Select field settings
-    add_action('gform_field_standard_settings', [
-      'GF_Field_Group_Contact_Select',
-      'field_standard_settings',
-    ], 10, 2);
+      // Add the CiviCRM Group Contact Select field settings
+        add_action('gform_field_standard_settings', [
+        'GF_Field_Group_Contact_Select',
+        'field_standard_settings',
+        ], 10, 2);
 
-    add_action('gform_field_standard_settings', [
-      'GFCiviCRM\CiviCRM_Payment_Token',
-      'field_standard_settings',
-    ], 10, 2);
+        add_action('gform_field_standard_settings', [
+        'GFCiviCRM\CiviCRM_Payment_Token',
+        'field_standard_settings',
+        ], 10, 2);
 
-    // Notify if CiviCRM Site Key and/or API Key is empty
-    add_action( 'admin_notices', function() {
-      // Only if CMRF is not active
-      if ( !is_plugin_active( 'connector-civicrm-mcrestface/wpcmrf.php' ) ) {
-        $gf_civicrm_site_key = FieldsAddOn::get_instance()->get_plugin_setting( 'gf_civicrm_site_key' );
-        $gf_civicrm_api_key = FieldsAddOn::get_instance()->get_plugin_setting( 'gf_civicrm_api_key' );
-        $missing = [];
-        if ( !$gf_civicrm_site_key ) {
-          $missing[] = 'Site Key';
+      // Notify if CiviCRM Site Key and/or API Key is empty
+        add_action('admin_notices', function () {
+          // Only if CMRF is not active
+            if (!is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+                $gf_civicrm_site_key = FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_site_key');
+                $gf_civicrm_api_key = FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_api_key');
+                $missing = [];
+                if (!$gf_civicrm_site_key) {
+                    $missing[] = 'Site Key';
+                }
+                if (!$gf_civicrm_api_key) {
+                    $missing[] = 'API Key';
+                }
+                if (!empty($missing)) {
+                    $this->warn_keys_settings($missing);
+                }
+            }
+        });
+
+      // Notify the Webhook URL Merge Tags Replacer status
+        add_action('admin_notices', function () {
+            if (isset($_GET['subview']) && $_GET['subview'] === 'gf-civicrm') {
+                if (get_transient('gfcv_webhook_merge_tags_replacement_failure')) {
+                    $status_message = 'Something went wrong.';
+                    $notice_class = 'error';
+                } elseif (get_transient('gfcv_webhook_merge_tags_replacement_success')) {
+                    $status_message = 'Success!';
+                    $notice_class = 'success';
+                } else {
+                    return; // Do nothing if there are no statuses
+                }
+
+                $message = sprintf(
+                    '<p><strong>%1$s</strong></p><p>%2$s</p>',
+                    esc_html__('Executed Webhook URL Merge Tags Replacements.', 'gravityforms'),
+                    esc_html__($status_message, 'gravityforms'),
+                );
+
+                printf('<div class="notice notice-%s gf-notice" id="gform_status_notice">%s</div>', $notice_class, $message);
+            }
+        });
+
+        add_action('admin_init', [$this, 'maybe_run_merge_tags_replacer']);
+    }
+
+    public function maybe_run_merge_tags_replacer()
+    {
+        if (isset($_GET['gf_webhook_merge_tags_replacement_action']) && 'run' === $_GET['gf_webhook_merge_tags_replacement_action']) {
+          // Clear status messaging transients
+            delete_transient('gfcv_webhook_merge_tags_replacement_failure');
+            delete_transient('gfcv_webhook_merge_tags_replacement_success');
+
+          // Verify nonce for security.
+            if (! isset($_GET['gf_webhook_merge_tags_replacement_nonce']) || ! wp_verify_nonce($_GET['gf_webhook_merge_tags_replacement_nonce'], 'webhook_merge_tags_replacement_nonce')) {
+                wp_die(__('Security check failed', 'gf-civicrm'));
+            }
+
+          // Call the replacer function
+            $updater = Upgrader::get_instance();
+            $result = $updater->execute_webhook_url_merge_tags_replacements();
+
+            if (!$result || empty($result)) {
+                set_transient('gfcv_webhook_merge_tags_replacement_failure', true, 60);
+            } else {
+                set_transient('gfcv_webhook_merge_tags_replacement_success', true, 60);
+            }
+
+        // Redirect back to the CiviCRM Settings page with a status message
+            wp_redirect(
+                add_query_arg(
+                    [
+                    'page' => 'gf_settings',
+                    'subview' => 'gf-civicrm',
+                    ],
+                    admin_url('admin.php')
+                )
+            );
+            exit;
         }
-        if ( !$gf_civicrm_api_key ) {
-          $missing[] = 'API Key';
-        }
-        if ( !empty( $missing ) ) {
-          $this->warn_keys_settings( $missing );
-        }
-      }
-    } );
+    }
 
-    // Notify the Webhook URL Merge Tags Replacer status
-    add_action( 'admin_notices', function() {
-      if ( isset($_GET['subview']) && $_GET['subview'] === 'gf-civicrm' ) {
-        if (get_transient('gfcv_webhook_merge_tags_replacement_failure')) {
-          $status_message = 'Something went wrong.';
-          $notice_class = 'error';
-        } else if (get_transient('gfcv_webhook_merge_tags_replacement_success')) {
-          $status_message = 'Success!';
-          $notice_class = 'success';
+    public function init()
+    {
+        parent::init();
+
+        if ($this->is_gravityforms_supported() && class_exists('GF_Field')) {
+            require_once('includes/class-gf-civicrm-address-field.php');
+            $this->gf_civicrm_address_field = new Address_Field();
+        }
+    }
+
+    public function warn_auth_checksum($wrapper = '<div class="notice notice-warning is-dismissible">%s</div>')
+    {
+        $forms = GFAPI::get_forms();
+
+        $warnings = [];
+
+        foreach ($forms as $form) {
+            $settings = $this->get_form_settings($form);
+            if (!empty($settings['civicrm_auth_checksum'])) {
+                $settings_link = admin_url('admin.php?page=gf_edit_forms&view=settings&subview=gf-civicrm&id=' . $form['id']);
+                $warnings[] = sprintf(__('The Gravity Form "%s" has the <strong>nonfunctional</strong> CiviCRM auth checksum setting enabled. <a href="%s">Click here to edit the form settings.</a>', 'text-domain'), esc_html($form['title']), esc_url($settings_link));
+            }
+        }
+
+        if (!empty($warnings)) {
+            $notice_heading = __('Legacy setting enabled for form(s)');
+            $notice_footer  = sprintf(
+                __('For details on setting up an alternative method for checksum authentication, see the README section on <a target="_blank" href="%1$s">Processing form submissions as a specific Contact</a>'),
+                'https://github.com/agileware/gf-civicrm/blob/main/README.md#processing-form-submissions-as-a-specific-contact'
+            );
+            return sprintf($wrapper, '<h3>' . $notice_heading . '</h3><ul>' . implode('', $warnings) . '</ul><p>' . $notice_footer . '</p>');
         } else {
-          return; // Do nothing if there are no statuses
+            return null;
         }
-
-        $message = sprintf(
-            '<p><strong>%1$s</strong></p><p>%2$s</p>',
-            esc_html__( 'Executed Webhook URL Merge Tags Replacements.', 'gravityforms' ),
-            esc_html__( $status_message, 'gravityforms' ),
-        );
-
-        printf( '<div class="notice notice-%s gf-notice" id="gform_status_notice">%s</div>', $notice_class, $message );
-        }
-    } );
-
-    add_action( 'admin_init', [$this, 'maybe_run_merge_tags_replacer'] );
-    
-  }
-  
-  public function maybe_run_merge_tags_replacer() {
-    if ( isset( $_GET['gf_webhook_merge_tags_replacement_action'] ) && 'run' === $_GET['gf_webhook_merge_tags_replacement_action'] ) {
-      // Clear status messaging transients
-      delete_transient('gfcv_webhook_merge_tags_replacement_failure');
-      delete_transient('gfcv_webhook_merge_tags_replacement_success');
-
-      // Verify nonce for security.
-      if ( ! isset( $_GET['gf_webhook_merge_tags_replacement_nonce'] ) || ! wp_verify_nonce( $_GET['gf_webhook_merge_tags_replacement_nonce'], 'webhook_merge_tags_replacement_nonce' ) ) {
-          wp_die( __( 'Security check failed', 'gf-civicrm' ) );
-      }
-      
-      // Call the replacer function
-      $updater = Upgrader::get_instance();
-      $result = $updater->execute_webhook_url_merge_tags_replacements();
-
-      if ( !$result || empty($result) ){
-        set_transient( 'gfcv_webhook_merge_tags_replacement_failure', true, 60 );
-      } else {
-        set_transient( 'gfcv_webhook_merge_tags_replacement_success', true, 60 );
-      }
-      
-      // Redirect back to the CiviCRM Settings page with a status message
-      wp_redirect(
-        add_query_arg(
-          [
-            'page' => 'gf_settings',
-            'subview' => 'gf-civicrm',
-          ],
-          admin_url( 'admin.php' )
-        )
-      );
-      exit;
     }
-  }
-
-	public function init() {
-		parent::init();
-
-		if ( $this->is_gravityforms_supported() && class_exists('GF_Field') ) {
-			require_once( 'includes/class-gf-civicrm-address-field.php' );
-			$this->gf_civicrm_address_field = new Address_Field();
-		}
-	}
-
-	public function warn_auth_checksum($wrapper = '<div class="notice notice-warning is-dismissible">%s</div>') {
-		$forms = GFAPI::get_forms();
-
-		$warnings = [];
-
-		foreach ($forms as $form) {
-			$settings = $this->get_form_settings($form);
-			if (!empty($settings['civicrm_auth_checksum'])) {
-				$settings_link = admin_url( 'admin.php?page=gf_edit_forms&view=settings&subview=gf-civicrm&id=' . $form['id'] );
-				$warnings[] = sprintf( __( 'The Gravity Form "%s" has the <strong>nonfunctional</strong> CiviCRM auth checksum setting enabled. <a href="%s">Click here to edit the form settings.</a>', 'text-domain' ), esc_html( $form['title'] ), esc_url( $settings_link ) );
-			}
-		}
-
-		if(!empty($warnings)) {
-			$notice_heading = __( 'Legacy setting enabled for form(s)' );
-			$notice_footer  = sprintf(
-				__( 'For details on setting up an alternative method for checksum authentication, see the README section on <a target="_blank" href="%1$s">Processing form submissions as a specific Contact</a>' ),
-				'https://github.com/agileware/gf-civicrm/blob/main/README.md#processing-form-submissions-as-a-specific-contact' );
-			return sprintf( $wrapper, '<h3>' . $notice_heading . '</h3><ul>' . implode( '', $warnings ) . '</ul><p>' . $notice_footer . '</p>'  );
-		} else {
-			return NULL;
-		}
-	}
 
   /**
    * Displays a warning if either or both of the CiviCRM Site Key and CiviCRM API Key settings are empty/null.
-   * 
+   *
    * These are required for the {gf_civicrm_site_key} and {gf_civicrm_api_key} merge tags.
-   * 
+   *
    * @param array $settings        The missing settings.
    */
-  public function warn_keys_settings( $settings = [] ) {
-    if ( empty($settings) ) {
-      // Do nothing. We don't know what we're warning against.
-      return;
+    public function warn_keys_settings($settings = [])
+    {
+        if (empty($settings)) {
+          // Do nothing. We don't know what we're warning against.
+            return;
+        }
+
+        $settings_text = implode(' and ', $settings);
+
+        $message = sprintf(
+            '<p><strong>%1$s%2$s%3$s</strong></p><p>%4$s</p>',
+            $settings_text,
+            count($settings) > 1 ? ' are' : ' is',
+            esc_html__(' missing in the Gravity Forms CiviCRM Settings.', 'gravityforms'),
+            esc_html__('These are required for the {gf_civicrm_site_key} and {gf_civicrm_api_key} merge tags. If you are using these, please check your configuration.', 'gravityforms'),
+        );
+
+        printf('<div class="notice notice-warning gf-notice" id="gform_warn_missing_keys_notice">%s</div>', $message);
     }
-
-    $settings_text = implode(' and ', $settings);
-
-		$message = sprintf(
-      '<p><strong>%1$s%2$s%3$s</strong></p><p>%4$s</p>',
-      $settings_text,
-      count($settings) > 1 ? ' are' : ' is',
-      esc_html__( ' missing in the Gravity Forms CiviCRM Settings.', 'gravityforms' ),
-      esc_html__( 'These are required for the {gf_civicrm_site_key} and {gf_civicrm_api_key} merge tags. If you are using these, please check your configuration.', 'gravityforms' ),
-    );
-
-    printf( '<div class="notice notice-warning gf-notice" id="gform_warn_missing_keys_notice">%s</div>', $message );
-	}
 
   /**
    * Include gf-civicrm-fields.js when the form contains a 'group_contact_select' type field.
    *
    * @return array
    */
-  public function scripts() {
-    $scripts = [
-      [
+    public function scripts()
+    {
+        $scripts = [
+        [
         'handle'  => 'gf_civicrm_fields_js',
         'src'     => $this->get_base_url() . '/js/gf-civicrm-fields.js',
         'version' => $this->_version,
@@ -239,252 +250,285 @@ class FieldsAddOn extends GFAddOn {
         'enqueue' => [
           [ 'field_types' => ['group_contact_select', 'civicrm_payment_token', 'address'] ],
         ],
-      ],
-      [
-        'handle'  	=> 'gf_civicrm_address_fields',
-        'src'		=> $this->get_base_url() . '/js/gf-civicrm-address-fields.js',
-        'version'	=> $this->_version,
-        'deps'		=> ['jquery', 'wp-util'],
-        'in_footer'	=> true,
-        'enqueue' 	=> [
-		      [ $this->gf_civicrm_address_field, 'applyGFCiviCRMAddressField' ]
         ],
-      ],
-    ];
+        [
+        'handle'    => 'gf_civicrm_address_fields',
+        'src'       => $this->get_base_url() . '/js/gf-civicrm-address-fields.js',
+        'version'   => $this->_version,
+        'deps'      => ['jquery', 'wp-util'],
+        'in_footer' => true,
+        'enqueue'   => [
+              [ $this->gf_civicrm_address_field, 'applyGFCiviCRMAddressField' ]
+        ],
+        ],
+        ];
 
-    return array_merge(parent::scripts(), $scripts);
-  }
+        return array_merge(parent::scripts(), $scripts);
+    }
 
   /**
    * Include gf-civicrm-fields.css when the form contains a 'group_contact_select' type field.
    *
    * @return array
    */
-  public function styles() {
-    $styles = [
-      [
+    public function styles()
+    {
+        $styles = [
+        [
         'handle'  => 'gf_civicrm_fields_css',
         'src'     => $this->get_base_url() . '/css/gf-civicrm-fields.css',
         'version' => $this->_version,
         'enqueue' => [
           ['field_types' => ['group_contact_select', 'civicrm_payment_token']],
         ],
-      ],
-    ];
+        ],
+        ];
 
-    return array_merge(parent::styles(), $styles);
-  }
+        return array_merge(parent::styles(), $styles);
+    }
 
   /**
    * Add form settings tab, *only if* legacy settings are already set.
    */
-  public function add_form_settings_menu( $tabs, $form_id ) {
-	  $settings = $this->get_form_settings( $form_id );
+    public function add_form_settings_menu($tabs, $form_id)
+    {
+        $settings = $this->get_form_settings($form_id);
 
-	  if ( ! empty( $settings['civicrm_auth_checksum'] ) ) {
-		  return parent::add_form_settings_menu( $tabs, $form_id );
-	  } else {
-		  return $tabs;
-	  }
-  }
+        if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+            $tabs[] = array (
+            'name' => $this->get_slug(),
+            'label' => 'CiviCRM MCRF',
+            'icon' => 'gform-icon--cog',
+            'query' => array (
+            'cid' => null,
+            'nid' => null,
+            'fid' => null,
+            ),
+            'capabilities' => array (
+            0 => 'gravityforms_edit_forms',
+            ),
+            );
+        }
 
-	public function form_settings_fields( $form ) {
-		$settings = $this->get_form_settings( $form ) ?: [];
-
-		$fields = [];
-
-		// Legacy field, don't allow for new forms.
-		if ( ! empty( $settings['civicrm_auth_checksum'] ) ) {
-			$fields[] = [
-				'type'        => 'checkbox',
-				'name'        => 'civicrm_auth_checksum',
-				'description' => wp_kses(sprintf(__(
-					'<strong>Nonfunctional</strong>: This option is no longer functional due to a <strong>security risk</strong>. Switch to the replacement workflow using Form Processor capabilities outlined <a target="_blank" href="%s">in the README</a>.',
-					'gf-civicrm'
-				), 'https://github.com/agileware/gf-civicrm/tree/main?tab=readme-ov-file#processing-form-submissions-as-a-specific-contact'), 'data'),
-				'choices'     => [
-					[
-						'label' => esc_html__( 'Allow authentication with checksum', 'gf-civicrm' ),
-						'name'  => 'civicrm_auth_checksum'
-					]
-				]
-		  ];
+        if (! empty($settings['civicrm_auth_checksum'])) {
+            return parent::add_form_settings_menu($tabs, $form_id);
+        } else {
+            return $tabs;
+        }
     }
 
-    if ( is_plugin_active( 'connector-civicrm-mcrestface/wpcmrf.php' ) ) {
-      // CiviCRM McRestFace
-      $fields[] = [
-        'label' => esc_html__( 'CiviCRM REST Connection Profile', 'gf-civicrm' ),
-        'type'        => 'select',
-        'name'        => 'civicrm_rest_connection',
-        'description' => esc_html__(
-          'Select which CMRF connection profile to use for this form.',
-          'gf-civicrm'
-        ),
-        'choices'     => $this->get_cmrf_profile_options()
-      ];
+    public function form_settings_fields($form)
+    {
+        $settings = $this->get_form_settings($form) ?: [];
+
+        $fields = [];
+        $fields[] = [
+          'type'        => 'checkbox',
+          'name'        => 'civicrm_use_mcrf',
+          'description' => esc_html__('Whether to use the CiviCRM REST Connection Profile for this form.', 'gf-civicrm'),
+          'choices'     => [
+            [
+              'label' => esc_html__('Use CiviCRM REST Connection Profile', 'gf-civicrm'),
+              'name'  => 'civicrm_use_mcrf'
+            ]
+          ]
+        ];
+
+        // Legacy field, don't allow for new forms.
+        if (! empty($settings['civicrm_auth_checksum'])) {
+            $fields[] = [
+                'type'        => 'checkbox',
+                'name'        => 'civicrm_auth_checksum',
+                'description' => wp_kses(sprintf(__(
+                    '<strong>Nonfunctional</strong>: This option is no longer functional due to a <strong>security risk</strong>. Switch to the replacement workflow using Form Processor capabilities outlined <a target="_blank" href="%s">in the README</a>.',
+                    'gf-civicrm'
+                ), 'https://github.com/agileware/gf-civicrm/tree/main?tab=readme-ov-file#processing-form-submissions-as-a-specific-contact'), 'data'),
+                'choices'     => [
+                    [
+                        'label' => esc_html__('Allow authentication with checksum', 'gf-civicrm'),
+                        'name'  => 'civicrm_auth_checksum'
+                    ]
+                ]
+            ];
+        }
+
+        if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+          // CiviCRM McRestFace
+            $fields[] = [
+            'label' => esc_html__('CiviCRM REST Connection Profile', 'gf-civicrm'),
+            'type'        => 'select',
+            'name'        => 'civicrm_rest_connection',
+            'description' => esc_html__(
+                'Select which CMRF connection profile to use for this form.',
+                'gf-civicrm'
+            ),
+            'dependency' => array( 'field' => 'civicrm_use_mcrf', 'values' => array( 1 ) ),
+            'choices'     => $this->get_cmrf_profile_options()
+            ];
+        }
+
+        if (!empty($fields)) {
+            return [
+                [
+                    'title'  => esc_html__('CiviCRM Settings', 'gf-civicrm'),
+                    'fields' => &$fields,
+                ],
+            ];
+        } else {
+            return [];
+        }
     }
 
-		if(!empty($fields)) {
-			return [
-				[
-					'title'  => esc_html__( 'CiviCRM Settings', 'gf-civicrm' ),
-					'fields' => &$fields,
-				],
-			];
-		} else {
-			return [];
-		}
-	}
-
-	public function plugin_settings_fields() {
-    $nonce = wp_create_nonce( 'webhook_merge_tags_replacement_nonce' );
-    $action_url = add_query_arg( array(
+    public function plugin_settings_fields()
+    {
+        $nonce = wp_create_nonce('webhook_merge_tags_replacement_nonce');
+        $action_url = add_query_arg(array(
         'gf_webhook_merge_tags_replacement_action' => 'run',
         'gf_webhook_merge_tags_replacement_nonce'  => $nonce,
-    ), admin_url( 'admin.php?page=gf_settings&subview=gf-civicrm' ) );
+        ), admin_url('admin.php?page=gf_settings&subview=gf-civicrm'));
 
-    $fields = [];
+        $fields = [];
 
-    $fields[] = [
-      'title'       => esc_html__( 'CiviCRM Settings', 'gf-civicrm' ),
-      'description' => esc_html__( 'Global settings for CiviCRM add-on', 'gf-civicrm' ),
-      'fields'      => [ 
+        $fields[] = [
+        'title'       => esc_html__('CiviCRM Settings', 'gf-civicrm'),
+        'description' => esc_html__('Global settings for CiviCRM add-on', 'gf-civicrm'),
+        'fields'      => [
         [
           'type'          => 'checkbox',
           'name'          => 'gf_civicrm_flags',
           'default_value' => [ 'civicrm_multi_json' ],
           'choices' => [
             [
-              'label'   => esc_html__( 'Use JSON encoding for Checkbox and Multiselect values in webhooks (recommended)', 'gf_civicrm' ),
+              'label'   => esc_html__('Use JSON encoding for Checkbox and Multiselect values in webhooks (recommended)', 'gf_civicrm'),
               'name'    => 'civicrm_multi_json',
             ],
             [
-              'label'   => esc_html__( 'Enable pre-releases for updates.', 'gf_civicrm' ),
+              'label'   => esc_html__('Enable pre-releases for updates.', 'gf_civicrm'),
               'name'    => 'enable_prereleases',
-              'tooltip' => esc_html__( 'Opt-in to including pre-releases/beta releases for GF CiviCRM updates. Please note that pre-releases may be unstable, so make sure to take a backup of your database before performing updates with this option enabled.', 'simpleaddon' ),
+              'tooltip' => esc_html__('Opt-in to including pre-releases/beta releases for GF CiviCRM updates. Please note that pre-releases may be unstable, so make sure to take a backup of your database before performing updates with this option enabled.', 'simpleaddon'),
             ],
           ],
         ],
-      ],
-    ];
+        ],
+        ];
 
-    if ( is_plugin_active( 'connector-civicrm-mcrestface/wpcmrf.php' ) ) {
-      $fields[] = [ // CiviCRM McRestFace or Local
-        'title'         => esc_html__( 'CiviCRM REST Connection Profile', 'gf-civicrm' ),
-        'description'   => wp_kses_post( sprintf(
-                            __( 'Select which CMRF connection profile to use for this form. <a href="%s">Configure connection profiles here.</a>', 'gf-civicrm' ),
-                            esc_url( add_query_arg( [ 'page' => 'wpcmrf_admin' ], admin_url( 'options-general.php' ) ) )
-                          ) ),
-        'fields'        => [ [
-          'type'          => 'select',
-          'name'          => 'civicrm_rest_connection',
-          'choices'       => $this->get_cmrf_profile_options( true ),
-        ] ],
-      ];
-    }
+        if (is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+            $fields[] = [ // CiviCRM McRestFace or Local
+            'title'         => esc_html__('CiviCRM REST Connection Profile', 'gf-civicrm'),
+            'description'   => wp_kses_post(sprintf(
+                __('Select which CMRF connection profile to use for this form. <a href="%s">Configure connection profiles here.</a>', 'gf-civicrm'),
+                esc_url(add_query_arg([ 'page' => 'wpcmrf_admin' ], admin_url('options-general.php')))
+            )),
+            'fields'        => [ [
+              'type'          => 'select',
+              'name'          => 'civicrm_rest_connection',
+              'choices'       => $this->get_cmrf_profile_options(true),
+            ] ],
+            ];
+        }
 
     // Only use these fields if CMRF is not active.
-    if ( !is_plugin_active( 'connector-civicrm-mcrestface/wpcmrf.php' ) ) {
-      $fields[] = [
-        'title'       => esc_html__( 'CiviCRM Site Key', 'gf-civicrm' ),
-        'description' => esc_html__( 'Provide the CiviCRM site key for making API calls, can be output using the merge tag {gf_civicrm_site_key}.', 'gf-civicrm' ),
-        'fields'      => [ [
-          'type'          => 'text',
-          'name'          => 'gf_civicrm_site_key',
-          'default_value' => '',
-        ] ],
-      ];
-  
-      $fields[] = [
-        'title'       => esc_html__( 'CiviCRM API Key', 'gf-civicrm' ),
-        'description' => esc_html__( 'Provide the CiviCRM API key for making API calls, can be output using the merge tag {gf_civicrm_api_key}.', 'gf-civicrm' ),
-        'fields'      => [ [
-          'type'          => 'text',
-          'name'          => 'gf_civicrm_api_key',
-          'default_value' => '',
-        ] ],
-      ];
-    }
+        if (!is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+            $fields[] = [
+            'title'       => esc_html__('CiviCRM Site Key', 'gf-civicrm'),
+            'description' => esc_html__('Provide the CiviCRM site key for making API calls, can be output using the merge tag {gf_civicrm_site_key}.', 'gf-civicrm'),
+            'fields'      => [ [
+              'type'          => 'text',
+              'name'          => 'gf_civicrm_site_key',
+              'default_value' => '',
+            ] ],
+            ];
 
-    $fields[] = [
-      'title'       => esc_html__( 'Webhook Alerts', 'gf-civicrm' ),
-      'description' => nl2br(esc_html__( "Webhook alerts will be sent to the email provided below.", 'gf-civicrm' )),
-      'fields'      => [ [
+            $fields[] = [
+            'title'       => esc_html__('CiviCRM API Key', 'gf-civicrm'),
+            'description' => esc_html__('Provide the CiviCRM API key for making API calls, can be output using the merge tag {gf_civicrm_api_key}.', 'gf-civicrm'),
+            'fields'      => [ [
+            'type'          => 'text',
+            'name'          => 'gf_civicrm_api_key',
+            'default_value' => '',
+            ] ],
+            ];
+        }
+
+        $fields[] = [
+        'title'       => esc_html__('Webhook Alerts', 'gf-civicrm'),
+        'description' => nl2br(esc_html__("Webhook alerts will be sent to the email provided below.", 'gf-civicrm')),
+        'fields'      => [ [
         'type'          => 'checkbox',
         'name'          => 'gf_civicrm_alerts',
         'choices' => [
           [
-            'label'   => esc_html__( 'Enable email alerts', 'gf_civicrm' ),
+            'label'   => esc_html__('Enable email alerts', 'gf_civicrm'),
             'name'    => 'enable_emails',
             'default_value' => true,
           ],
         ],
-      ],
-      [
+        ],
+        [
         'type'          => 'text',
         'name'          => 'gf_civicrm_alerts_email',
         'default_value' => '',
-        'validation_callback' => function( $field, $value ) {
+        'validation_callback' => function ($field, $value) {
           // Validate the value is actually an email
-          if ( ! is_email( trim( $value ) ) ) {
-            $field->set_error( __( 'Please enter a valid email address.', 'gravityforms' ) );
-          }
+            if (! is_email(trim($value))) {
+                $field->set_error(__('Please enter a valid email address.', 'gravityforms'));
+            }
         }
-      ] ],
-    ];
+        ] ],
+        ];
 
-    $fields[] = [
-      'title'       => esc_html__( 'Import/Export Directory', 'gf-civicrm' ),
-      'description' => nl2br(esc_html__( "Define the path to the import/export directory, relative to the server document root. Used by Export GF CiviCRM and Import GF CiviCRM.\n\nYou can modify the subdirectories using the 'gf-civicrm/export-directory' and 'gf-civicrm/fp-export-directory' filters.", 'gf-civicrm' )),
-      'fields'      => [ [
+        $fields[] = [
+        'title'       => esc_html__('Import/Export Directory', 'gf-civicrm'),
+        'description' => nl2br(esc_html__("Define the path to the import/export directory, relative to the server document root. Used by Export GF CiviCRM and Import GF CiviCRM.\n\nYou can modify the subdirectories using the 'gf-civicrm/export-directory' and 'gf-civicrm/fp-export-directory' filters.", 'gf-civicrm')),
+        'fields'      => [ [
         'type'          => 'text',
         'name'          => 'gf_civicrm_import_export_directory',
         'default_value' => 'CRM/gf-civicrm-exports',
-      ] ],
-    ];
+        ] ],
+        ];
 
-    $fields[] = [
-      'title'       => esc_html__( 'Webhook URL Merge Tags Replacements', 'gf-civicrm' ),
-      'description' => __( 'Replaces the REST API url, and CiviCRM Site keys and API keys in Gravity Forms webhook request URLs with their equivalent merge tags, for all webhooks feeds. Saves the CiviCRM Site Key and API key in the settings.<br /><br /><strong>CAUTION:</strong> It is recommended to take a backup before running this function.', 'gf-civicrm' ),
-      'fields'      => [ [
+        $fields[] = [
+        'title'       => esc_html__('Webhook URL Merge Tags Replacements', 'gf-civicrm'),
+        'description' => __('Replaces the REST API url, and CiviCRM Site keys and API keys in Gravity Forms webhook request URLs with their equivalent merge tags, for all webhooks feeds. Saves the CiviCRM Site Key and API key in the settings.<br /><br /><strong>CAUTION:</strong> It is recommended to take a backup before running this function.', 'gf-civicrm'),
+        'fields'      => [ [
         'name'  => 'webhook_merge_tags_replacer',
         'label' => '',
         'type'  => 'html',
-        'html'  => '<a href="' . esc_url( $action_url ) . '" class="button">Replace the Merge Tags</a>',
-      ] ],
-    ];
+        'html'  => '<a href="' . esc_url($action_url) . '" class="button">Replace the Merge Tags</a>',
+        ] ],
+        ];
 
-		return $fields;
-	}
+        return $fields;
+    }
 
   /**
-	 * Build choices for selectiing CMRF connection profiles on a global or per-form basis.
-	 */
-	public function get_cmrf_profile_options( $is_global = false ) {
-		$options = [];
+     * Build choices for selectiing CMRF connection profiles on a global or per-form basis.
+     */
+    public function get_cmrf_profile_options($is_global = false)
+    {
+        $options = [];
 
-		// Null or Default options
-		if ( $is_global ) {
-			$options[] = [
-				'label' => esc_html__( "None", 'gf_civicrm' ),
-				'value' => ""
-			];
-		} else {
-			$options[] = [
-				'label' => esc_html__( "Default", 'gf_civicrm' ),
-				'value' => "default"
-			];
-		}
+        // Null or Default options
+        if ($is_global) {
+            $options[] = [
+                'label' => esc_html__("None", 'gf_civicrm'),
+                'value' => ""
+            ];
+        } else {
+            $options[] = [
+                'label' => esc_html__("Default", 'gf_civicrm'),
+                'value' => "default"
+            ];
+        }
 
-		$profiles = get_profiles();
-		foreach ($profiles as $profile_id => $profile) {
-			$options[] = [
-				'label' => esc_html__( $profile['title'], 'gf_civicrm' ),
-				'value' => $profile_id
-			];
-		}
+        $profiles = get_profiles();
+        foreach ($profiles as $profile_id => $profile) {
+            $options[] = [
+                'label' => esc_html__($profile['title'], 'gf_civicrm'),
+                'value' => $profile_id
+            ];
+        }
 
-		return $options;
-	}
+        return $options;
+    }
 }

--- a/gf-civicrm.php
+++ b/gf-civicrm.php
@@ -736,6 +736,7 @@ function replace_merge_tags( $text, $form, $entry, $url_encode, $esc_html, $nl2b
 		$profile_name = get_rest_connection_profile();
 		$profiles     = get_profiles();
 		$plugin_active = is_plugin_active( 'connector-civicrm-mcrestface/wpcmrf.php' );
+		$use_mcrf      = boolval( rgars( $form, 'gf-civicrm/civicrm_use_mcrf' ) );
 
 		if ( $plugin_active && isset( $profiles[ $profile_name ] ) ) {
 			$profile = $profiles[ $profile_name ];
@@ -753,7 +754,11 @@ function replace_merge_tags( $text, $form, $entry, $url_encode, $esc_html, $nl2b
 			$text = str_replace( $gf_civicrm_api_key_merge_tag, $gf_civicrm_api_key, $text );
 		}
 
-		if ( $needs_api_url ) {
+		if ( $needs_api_url && $use_mcrf ) {
+			$form_profile_name = rgars( $form, 'gf-civicrm/civicrm_rest_connection' );
+			if ( 'default' !== $form_profile_name && isset( $profiles[$form_profile_name] ) ) {
+				$profile = $profiles[$form_profile_name];
+			}
 			$gf_civicrm_api_url = $profile ? ( ( ! is_array( $profile['function'] ) && 'GFCiviCRM\gf_civicrm_wpcmrf_api' === $profile['function'] ) ? $profile['url'] : $gf_civicrm_rest_api_url_merge_tag ) : $gf_civicrm_rest_api_url_merge_tag;
 			$text = str_replace( $gf_civicrm_rest_api_url_merge_tag, $gf_civicrm_api_url, $text );
 		}

--- a/gf-civicrm.php
+++ b/gf-civicrm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Plugin Name: Gravity Forms CiviCRM Integration
  * Plugin URI: https://github.com/agileware/gf-civicrm
@@ -24,7 +25,9 @@
 
 namespace GFCiviCRM;
 
-use Civi\Api4\{OptionValue, OptionGroup, Contact};
+use Civi\Api4\OptionValue;
+use Civi\Api4\OptionGroup;
+use Civi\Api4\Contact;
 use CRM_Core_Exception;
 use GFCommon;
 use GFAddon;
@@ -35,21 +38,24 @@ use GFFormsModel;
 
 const BEFORE_CHOICES_SETTING = 1350;
 
-define( 'GF_CIVICRM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
-define( 'GF_CIVICRM_PLUGIN_SLUG', plugin_basename( __FILE__ ) );
-define( 'GF_CIVICRM_PLUGIN_GITHUB_REPO', 'agileware/gf-civicrm' ); // GitHub username and repo
+define('GF_CIVICRM_PLUGIN_PATH', plugin_dir_path(__FILE__));
+define('GF_CIVICRM_PLUGIN_SLUG', plugin_basename(__FILE__));
+define('GF_CIVICRM_PLUGIN_GITHUB_REPO', 'agileware/gf-civicrm'); // GitHub username and repo
 
 // Include the updater class
 require_once GF_CIVICRM_PLUGIN_PATH . 'includes/class-gf-civicrm-upgrader.php';
 
-add_action('plugins_loaded', function() {
-	// Include the updater class
-	require_once GF_CIVICRM_PLUGIN_PATH . 'includes/class-gf-civicrm-upgrader.php';
+add_action(
+  'plugins_loaded',
+  function () {
+    // Include the updater class
+    require_once GF_CIVICRM_PLUGIN_PATH . 'includes/class-gf-civicrm-upgrader.php';
 
-	// Initialize the updater
-	$updater = new Upgrader( __FILE__ );
-	$updater->init();
-});
+    // Initialize the updater
+    $updater = new Upgrader(__FILE__);
+    $updater->init();
+  }
+);
 
 register_activation_hook(__FILE__, 'GFCiviCRM\check_plugin_dependencies');
 
@@ -57,283 +63,310 @@ register_activation_hook(__FILE__, 'GFCiviCRM\check_plugin_dependencies');
  * Either civicrm or wpcmrf plugins must be active.
  * This is not supported by the Dependencies header, so implement our own check.
  */
-function check_plugin_dependencies() {
-	// Check if CiviCRM or WP CMRF plugins are active
-	if ( ! is_plugin_active( 'civicrm/civicrm.php' ) && ! is_plugin_active( 'connector-civicrm-mcrestface/wpcmrf.php' ) ) {
-        $notice = sprintf(
-        /* translators: 1: this plugin name, 2, 3: required plugin names */
-            esc_html__( 'Before activating %1$s, you must first activate either %2$s or %3$s.', 'gf-civicrm' ),
-            'Gravity Forms CiviCRM Integration',
-            '<a href="https://wordpress.org/plugins/connector-civicrm-mcrestface/">Connector to CiviCRM with CiviMcRestFace</a>',
-            'CiviCRM' );
+function check_plugin_dependencies()
+{
+  // Check if CiviCRM or WP CMRF plugins are active
+  if (! is_plugin_active('civicrm/civicrm.php') && ! is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php')) {
+    $notice = sprintf(
+      /* translators: 1: this plugin name, 2, 3: required plugin names */
+      esc_html__('Before activating %1$s, you must first activate either %2$s or %3$s.', 'gf-civicrm'),
+      'Gravity Forms CiviCRM Integration',
+      '<a href="https://wordpress.org/plugins/connector-civicrm-mcrestface/">Connector to CiviCRM with CiviMcRestFace</a>',
+      'CiviCRM'
+    );
 
-        // Show an error message and exit immediately
-		\wp_die( $notice, __( 'Plugin Activation Error', 'gf-civicrm' ), [ 'back_link' => TRUE ] );
-	}
+    // Show an error message and exit immediately
+    \wp_die($notice, __('Plugin Activation Error', 'gf-civicrm'), array('back_link' => true));
+  }
 }
 
 // Load wpcmrf integration
-add_action( 'gform_loaded', 'GFCiviCRM\gf_civicrm_wpcmrf_bootstrap', 5 );
+add_action('gform_loaded', 'GFCiviCRM\gf_civicrm_wpcmrf_bootstrap', 5);
 
-function gf_civicrm_wpcmrf_bootstrap() {
-	require_once( GF_CIVICRM_PLUGIN_PATH . 'includes/class-gf-civicrm-exception.php' );
-	require_once( GF_CIVICRM_PLUGIN_PATH . 'includes/gf-civicrm-wpcmrf.php' );
+function gf_civicrm_wpcmrf_bootstrap()
+{
+  require_once GF_CIVICRM_PLUGIN_PATH . 'includes/class-gf-civicrm-exception.php';
+  require_once GF_CIVICRM_PLUGIN_PATH . 'includes/gf-civicrm-wpcmrf.php';
 }
 
 /**
  * Replace choices in Gravity Forms with CiviCRM data
  *
- * @param array $form
+ * @param array  $form
  * @param string $context
  *
  * @return array
  * @throws \API_Exception
  * @throws \Civi\API\Exception\UnauthorizedException
  */
-function do_civicrm_replacement( $form, $context ) {
-	static $civi_fp_fields;
-	static $option_group_ids;
+function do_civicrm_replacement($form, $context)
+{
+  static $civi_fp_fields;
+  static $option_group_ids;
 
-	// Check if a CiviCRM installation exists
-	if ( check_civicrm_installation()['is_error'] ) {
-		return $form;
-	}
+  // Check if a CiviCRM installation exists
+  if (check_civicrm_installation()['is_error']) {
+    return $form;
+  }
 
-	foreach ( $form['fields'] as &$field ) {
-		if ( property_exists( $field, 'choices' ) && property_exists( $field, 'civicrmOptionGroup' ) &&
-		     preg_match( '{(?:^|\s) civicrm (?: __ (?<option_group>\S+) | _fp__ (?<processor>\S*?) __ (?<field_name> \S*))}x', $field->civicrmOptionGroup, $matches ) ) {
+  foreach ($form['fields'] as &$field) {
+    if (
+      property_exists($field, 'choices') && property_exists($field, 'civicrmOptionGroup')
+      && preg_match('{(?:^|\s) civicrm (?: __ (?<option_group>\S+) | _fp__ (?<processor>\S*?) __ (?<field_name> \S*))}x', $field->civicrmOptionGroup, $matches)
+    ) {
+      // Get the CiviCRM REST Connection Profile. This may be the local CiviCRM connection if no profile is set.
+      $profile_name = get_rest_connection_profile($form);
 
-			// Get the CiviCRM REST Connection Profile. This may be the local CiviCRM connection if no profile is set.
-			$profile_name = get_rest_connection_profile( $form );
+      ['option_group' => $option_group, 'processor' => $processor, 'field_name' => $field_name] = $matches;
 
-			[ 'option_group' => $option_group, 'processor' => $processor, 'field_name' => $field_name ] = $matches;
+      $default_option = null;
 
-			$default_option = NULL;
+      $field->inputs = null;
 
-            $field->inputs = NULL;
+      if ($option_group) {
+        if (empty($option_group_ids[$option_group])) {
+          // Get the option group id from the name, since it's more reliable
+          $api_params        = array(
+            'sequential'          => 1,
+            'return'              => array('id', 'name'),
+            'name'                => $option_group,
+            'is_active'           => 1,
+            'api.OptionValue.get' => array(
+              'return'    => array('id', 'label', 'value', 'is_default'),
+              'is_active' => 1,
+              'sort'      => 'weight ASC',
+            ),
+          );
+          $option_group_data = api_wrapper($profile_name, 'OptionGroup', 'getsingle', $api_params, array('limit' => 1));
 
-			if ( $option_group ) {
-				if ( empty( $option_group_ids[$option_group] ) ) {
-					// Get the option group id from the name, since it's more reliable
-					$api_params = [
-						'sequential' => 1,
-  						'return' => ["id", "name"],
-						'name'		=> $option_group,
-						'is_active' => 1,
-						'api.OptionValue.get' => [
-							'return' => ["id", "label", "value", "is_default"],
-							'is_active' => 1,
-							'sort' => "weight ASC"
-						],
-					];
-					$option_group_data = api_wrapper( $profile_name, 'OptionGroup', 'getsingle', $api_params, ['limit' => 1] );
+          if (! $option_group_data || ! $option_group_data['api.OptionValue.get']['values']) {
+            // TODO log an error
+            continue; // No group found for the given name
+          }
 
-					if ( !$option_group_data || !$option_group_data['api.OptionValue.get']['values'] ) {
-						// TODO log an error
-						continue; // No group found for the given name
-					}
+          if (! $option_group_data['api.OptionValue.get']['values']) {
+            // TODO log an error
+            continue; // No options found for the given group
+          } else {
+            $options                      = $option_group_data['api.OptionValue.get']['values'] ?? array();
+            $option_group_data['options'] = $options;
+            unset($option_group_data['api.OptionValue.get']);
+          }
 
-					if ( !$option_group_data['api.OptionValue.get']['values'] ) {
-						// TODO log an error
-						continue; // No options found for the given group
-					} else {
-						$options = $option_group_data['api.OptionValue.get']['values'] ?? [];
-						$option_group_data['options'] = $options;
-						unset($option_group_data['api.OptionValue.get']);
-					}
+          $option_group_ids[$option_group] = $option_group_data;
+        }
 
-					$option_group_ids[$option_group] = $option_group_data;
-				}
+        $field->choices = array();
 
-                $field->choices = [];
+        // Build the options
+        foreach ($option_group_ids[$option_group]['options'] as ['value' => $value, 'label' => $label, 'is_default' => $is_default]) {
+          $field->choices[] = array(
+            'text'       => $label,
+            'value'      => $value,
+            'isSelected' => (bool) ($is_default ?? false),
+          );
+        }
+      } elseif ($processor && $field_name) {
+        try {
+          if (! isset($civi_fp_fields[$processor])) {
+            $api_params                   = array('api_action' => $processor);
+            $api_options                  = array('limit' => 0);
+            $civi_fp_fields[$processor] = api_wrapper($profile_name, 'FormProcessor', 'getfields', $api_params, $api_options) ?? array();
+          }
 
-				// Build the options
-                foreach ( $option_group_ids[$option_group]['options'] as [ 'value' => $value, 'label' => $label, 'is_default' => $is_default ] ) {
-					$field->choices[] = [
-						'text'       => $label,
-						'value'      => $value,
-						'isSelected' => (bool) ( $is_default ?? FALSE )
-					];
-                }
-			} elseif ( $processor && $field_name ) {
-				try {
-					if ( ! isset( $civi_fp_fields[$processor] ) ) {
-						$api_params = [ 'api_action' => $processor ];
-						$api_options = [ 'limit' => 0, ];
-						$civi_fp_fields[ $processor ] = api_wrapper( $profile_name, 'FormProcessor', 'getfields', $api_params, $api_options ) ?? [];
-					}
+          if (isset($field->defaultValue) && ! empty($field->defaultValue)) {
+            // If the field has a default value set then that has priority
+            $default_option = $field->defaultValue;
+          } else {
+            // Otherwise, retrieve the default value from the form processor
+            $default_option = fp_tag_default(
+              array(
+                $field->civicrmOptionGroup,
+                $processor,
+                $field_name,
+              ),
+              null,
+              true
+            );
+          }
 
-					if ( isset( $field->defaultValue ) && ! empty( $field->defaultValue ) ) {
-						// If the field has a default value set then that has priority
-						$default_option = $field->defaultValue;
-					} else {
-						// Otherwise, retrieve the default value from the form processor
-						$default_option = fp_tag_default( [
-							$field->civicrmOptionGroup,
-							$processor,
-							$field_name,
-						], NULL, TRUE );
-					}
+          $field->choices = array();
 
-					$field->choices = [];
+          // Try to find the field once by name in the key
+          $fp_field = $civi_fp_fields[$processor][$field_name] ?? null;
 
-					// Try to find the field once by name in the key
-					$fp_field = $civi_fp_fields[$processor][$field_name] ?? null;
+          // If not found by key, search by 'name' field
+          if (! $fp_field) {
+            foreach ($civi_fp_fields[$processor] as $candidate) {
+              if (isset($candidate['name']) && $candidate['name'] === $field_name) {
+                $fp_field = $candidate;
+                break;
+              }
+            }
+          }
 
-					// If not found by key, search by 'name' field
-					if ( ! $fp_field ) {
-						foreach ( $civi_fp_fields[$processor] as $candidate ) {
-							if ( isset( $candidate['name'] ) && $candidate['name'] === $field_name ) {
-								$fp_field = $candidate;
-								break;
-							}
-						}
-					}
+          // Build the options list
+          if ($fp_field && ! empty($fp_field['options'])) {
+            foreach ($fp_field['options'] as $value => $label) {
+              $field->choices[] = array(
+                'text'       => $label,
+                'value'      => $value,
+                'isSelected' => ((is_array($default_option) && in_array($value, $default_option)) || ($value == $default_option)),
+              );
+            }
 
-					// Build the options list
-					if ( $fp_field && ! empty( $fp_field['options'] ) ) {
-						foreach ( $fp_field['options'] as $value => $label ) {
-							$field->choices[] = [
-								'text'       => $label,
-								'value'      => $value,
-								'isSelected' => ( ( is_array( $default_option ) && in_array( $value, $default_option ) ) || ( $value == $default_option ) ),
-							];
-						}
+            // Force the 'Show Values' option to be set, required for the label/value pairs to be saved
+            $field['enableChoiceValue'] = true;
+          }
+        } catch (CRM_Core_Exception $e) {
+          // Couldn't get form processor instance, don't try to set options
+          return $form;
+        }
+      }
 
-						// Force the 'Show Values' option to be set, required for the label/value pairs to be saved
-						$field['enableChoiceValue'] = true;
-					}
+      // Add checkboxes to the form entry meta
+      if ($field->type == 'checkbox') {
+        $i             = 0;
+        $field->inputs = array();
+        foreach ($field->choices as ['label' => $label]) {
+          $field->inputs[] = array(
+            // Avoid multiples of 10, allegedly these are problematic
+            'id'    => $field->id . '.' . (++$i % 10 ? $i : ++$i),
+            'label' => $label,
+          );
+        }
+      }
 
-				} catch ( CRM_Core_Exception $e ) {
-					// Couldn't get form processor instance, don't try to set options
-                    return $form;
-				}
-			}
+      // Adds default none option
+      if (($context === 'pre_render') && (! $field->isRequired) && ($field->type != 'multiselect') && ($field->type != 'checkbox')) {
+        array_unshift(
+          $field->choices,
+          array(
+            'text'       => __('- None -', 'gf-civicrm'),
+            'value'      => null,
+            'isSelected' => ! $default_option,
+          )
+        );
+      }
+    }
+  }
 
-			// Add checkboxes to the form entry meta
-			if ( $field->type == 'checkbox' ) {
-                $i = 0;
-                $field->inputs = [];
-				foreach ( $field->choices as [ 'label' => $label ] ) {
-					$field->inputs[] = [
-						// Avoid multiples of 10, allegedly these are problematic
-						'id'    => $field->id . '.' . ( ++ $i % 10 ? $i : ++ $i ),
-						'label' => $label,
-					];
-				}
-			}
-
-			// Adds default none option
-			if ( ( $context === 'pre_render' ) && ( ! $field->isRequired ) && ( $field->type != 'multiselect' ) && ( $field->type != 'checkbox' ) ) {
-				array_unshift( $field->choices, [
-					'text'       => __( '- None -', 'gf-civicrm' ),
-					'value'      => NULL,
-					'isSelected' => ! $default_option,
-				] );
-			}
-		}
-
-	}
-
-	return $form;
+  return $form;
 }
 
 /**
  * Adds custom merge tags to Insert Merge tags dropdowns.
  */
-function compose_merge_tags ( $merge_tags ) {
-	try {
-		$profile_name = get_rest_connection_profile();
-		$processors = api_wrapper( $profile_name, 'FormProcessorInstance', 'get', [ 'sequential' => 1], [ 'limit' => 0 ] );
+function compose_merge_tags($merge_tags)
+{
+  try {
+    $profile_name = get_rest_connection_profile();
+    $processors   = api_wrapper($profile_name, 'FormProcessorInstance', 'get', array('sequential' => 1), array('limit' => 0));
 
-		foreach ( $processors as ['inputs' => $inputs, 'name' => $pname, 'title' => $ptitle] ) {
-			foreach ( $inputs as ['name' => $iname, 'title' => $ititle] ) {
-				$merge_tags[] = [
-					'label' => sprintf( __( '%s / %s', 'gf-civicrm' ), $ptitle, $ititle ),
-					'tag'   => "{civicrm_fp.{$pname}.{$iname}}",
-				];
-			}
-		}
-	}
-	catch(\CRM_Core_Exception $e) {
-		// ...
-	}
+    foreach ($processors as ['inputs' => $inputs, 'name' => $pname, 'title' => $ptitle]) {
+      foreach ($inputs as ['name' => $iname, 'title' => $ititle]) {
+        $merge_tags[] = array(
+          'label' => sprintf(__('%1$s / %2$s', 'gf-civicrm'), $ptitle, $ititle),
+          'tag'   => "{civicrm_fp.{$pname}.{$iname}}",
+        );
+      }
+    }
+  } catch (\CRM_Core_Exception $e) {
+    // ...
+  }
 
-	return $merge_tags;
+  return $merge_tags;
 }
 
-function pre_render( $form, $ajax, $field_values, $context ) {
-	// @TODO - Refactor this to a single loop.
-	// @TODO - do_civicrm_replacement should be done first or last?
+function pre_render($form, $ajax, $field_values, $context)
+{
+  // @TODO - Refactor this to a single loop.
+  // @TODO - do_civicrm_replacement should be done first or last?
 
-	// Only do this on form_display
-	if ( $context !== 'form_display') {
-		return $form;
-	}
+  // Only do this on form_display
+  if ($context !== 'form_display') {
+    return $form;
+  }
 
-	// Use the default value if set for radio buttons
-	foreach ( $form['fields'] as &$field ) {
-		if ( $field->inputType != 'radio' ) {
-			continue;
-		}
+  // Use the default value if set for radio buttons
+  foreach ($form['fields'] as &$field) {
+    if ($field->inputType != 'radio') {
+      continue;
+    }
 
-		if ( isset( $field->defaultValue ) && ! empty( $field->defaultValue ) ) {
-			$default_value = $field->defaultValue;
+    if (isset($field->defaultValue) && ! empty($field->defaultValue)) {
+      $default_value = $field->defaultValue;
 
-			foreach ( $field->choices as &$choice ) {
-				if ( $choice['text'] == $default_value ) {
-					$choice['isSelected'] = TRUE;
-				}
-			}
-		}
-	}
+      foreach ($field->choices as &$choice) {
+        if ($choice['text'] == $default_value) {
+          $choice['isSelected'] = true;
+        }
+      }
+    }
+  }
 
-	// Apply comma separated default values to multiselect and checkbox fields
-	foreach ( $form['fields'] as &$field ) {
-		// Check if the field is of a type that should have comma-separated defaults
-		if ( in_array( $field->type, [ 'multiselect', 'checkbox' ] ) ) {
-			// Check if the custom comma-separated default setting is set
+  // Apply comma separated default values to multiselect and checkbox fields
+  foreach ($form['fields'] as &$field) {
+    // Check if the field is of a type that should have comma-separated defaults
+    if (in_array($field->type, array('multiselect', 'checkbox'))) {
+      // Check if the custom comma-separated default setting is set
 
-			/* @TODO
-			 * Test 1 - if this works with CiviCRM multi-value options
-			 * Test 2 - what happens when a merge tag returns a value which has commas in it, does it call this function again?
-			 */
+      /*
+            @TODO
+            * Test 1 - if this works with CiviCRM multi-value options
+            * Test 2 - what happens when a merge tag returns a value which has commas in it, does it call this function again?
+            */
 
-			if ( isset( $field->defaultValue ) && ! empty( $field->defaultValue ) ) {
-				$defaults = explode( ',', trim( $field->defaultValue ) );
-				// Apply these defaults to the field
-				foreach ( $field->choices as $i => $choice ) {
-					if ( in_array( trim( $choice['value'] ), $defaults ) ) {
-						$field->choices[ $i ]['isSelected'] = TRUE;
-					}
-				}
-			}
-		}
-	}
+      if (isset($field->defaultValue) && ! empty($field->defaultValue)) {
+        $defaults = explode(',', trim($field->defaultValue));
+        // Apply these defaults to the field
+        foreach ($field->choices as $i => $choice) {
+          if (in_array(trim($choice['value']), $defaults)) {
+            $field->choices[$i]['isSelected'] = true;
+          }
+        }
+      }
+    }
+  }
 
-	return do_civicrm_replacement( $form, 'pre_render' );
+  return do_civicrm_replacement($form, 'pre_render');
 }
 
-add_filter( 'gform_pre_render', 'GFCiviCRM\pre_render', 10, 4 );
-add_filter( '_disabled_gform_pre_process', function ( $form ) {
-	remove_filter( 'gform_pre_render', 'GFCiviCRM\pre_render' );
+add_filter('gform_pre_render', 'GFCiviCRM\pre_render', 10, 4);
+add_filter(
+  '_disabled_gform_pre_process',
+  function ($form) {
+    remove_filter('gform_pre_render', 'GFCiviCRM\pre_render');
 
-	return $form;
-} );
+    return $form;
+  }
+);
 
-add_filter( 'gform_pre_validation', function ( $form ) {
-	return do_civicrm_replacement( $form, 'pre_validation' );
-} );
-add_filter( 'gform_pre_submission_filter', function ( $form ) {
-	return do_civicrm_replacement( $form, 'pre_submission_filter' );
-} );
-add_filter( 'gform_admin_pre_render', function ( $form ) {
-	return do_civicrm_replacement( $form, 'admin_pre_render' );
-} );
+add_filter(
+  'gform_pre_validation',
+  function ($form) {
+    return do_civicrm_replacement($form, 'pre_validation');
+  }
+);
+add_filter(
+  'gform_pre_submission_filter',
+  function ($form) {
+    return do_civicrm_replacement($form, 'pre_submission_filter');
+  }
+);
+add_filter(
+  'gform_admin_pre_render',
+  function ($form) {
+    return do_civicrm_replacement($form, 'admin_pre_render');
+  }
+);
 
-add_filter( 'gform_username', function ( $username ) {
-	return sanitize_user( $username );
-} );
+add_filter(
+  'gform_username',
+  function ($username) {
+    return sanitize_user($username);
+  }
+);
 
 /**
  * Replaces comma separated values for multiselect with an actual array for JSON encoding
@@ -346,24 +379,21 @@ add_filter( 'gform_username', function ( $username ) {
  *
  * @return array
  */
-function fix_multi_values( \GF_Field $field, $entry, $input_id = '', $use_text = FALSE, $is_csv = FALSE ) {
-	$selected = [];
+function fix_multi_values(\GF_Field $field, $entry, $input_id = '', $use_text = false, $is_csv = false)
+{
+  $selected = array();
 
-	if ( empty( $input_id ) || absint( $input_id ) == $input_id ) {
+  if (empty($input_id) || absint($input_id) == $input_id) {
+    foreach ($field->inputs as $input) {
+      $index = (string) $input['id'];
 
-		foreach ( $field->inputs as $input ) {
+      if (! rgempty($index, $entry)) {
+        $selected[] = GFCommon::selection_display(rgar($entry, $index), $field, rgar($entry, 'currency'), $use_text);
+      }
+    }
+  }
 
-			$index = (string) $input['id'];
-
-			if ( ! rgempty( $index, $entry ) ) {
-				$selected[] = GFCommon::selection_display( rgar( $entry, $index ), $field, rgar( $entry, 'currency' ), $use_text );
-			}
-
-		}
-	}
-
-	return $selected;
-
+  return $selected;
 }
 
 /*
@@ -374,35 +404,37 @@ function fix_multi_values( \GF_Field $field, $entry, $input_id = '', $use_text =
 *
 */
 
-function convertInternationalCurrencyToFloat( $currencyValue ) {
-	// Remove all non-numeric characters except commas and dots
-	$number = preg_replace( '/[^\d.,]/', '', $currencyValue );
+function convertInternationalCurrencyToFloat($currencyValue)
+{
+  // Remove all non-numeric characters except commas and dots
+  $number = preg_replace('/[^\d.,]/', '', $currencyValue);
 
-	// Detect the use of comma or dot as the last decimal separator
-	if ( preg_match( '/\.\d{2}$/', $number ) ) {
-		// Dot is the decimal separator and comma as thousand separator
-		$number = str_replace( ',', '', $number );
-	} elseif ( preg_match( '/,\d{2}$/', $number ) ) {
-		// Comma is the decimal separator and dot as thousand separator
-		$number = str_replace( '.', '', $number );
-		$number = str_replace( ',', '.', $number );
-	} else {
-		// Assume no decimal places or unconventional usage, remove all commas and dots
-		$number = str_replace( [ ',', '.' ], '', $number );
-	}
+  // Detect the use of comma or dot as the last decimal separator
+  if (preg_match('/\.\d{2}$/', $number)) {
+    // Dot is the decimal separator and comma as thousand separator
+    $number = str_replace(',', '', $number);
+  } elseif (preg_match('/,\d{2}$/', $number)) {
+    // Comma is the decimal separator and dot as thousand separator
+    $number = str_replace('.', '', $number);
+    $number = str_replace(',', '.', $number);
+  } else {
+    // Assume no decimal places or unconventional usage, remove all commas and dots
+    $number = str_replace(array(',', '.'), '', $number);
+  }
 
-	// Convert to float cast as a string because webhook will complain otherwise
-	return (string) floatval( $number );
+  // Convert to float cast as a string because webhook will complain otherwise
+  return (string) floatval($number);
 }
 
 /*
 * Extend the maximum attempts for webhook calls, so Gravity Forms does not give up and start bailing
 */
 
-add_filter( 'gform_max_async_feed_attempts', 'GFCiviCRM\custom_max_async_feed_attempts' );
+add_filter('gform_max_async_feed_attempts', 'GFCiviCRM\custom_max_async_feed_attempts');
 
-function custom_max_async_feed_attempts( $max_attempts ) {
-	return 999999; // @TODO this could be a configurable option
+function custom_max_async_feed_attempts($max_attempts)
+{
+  return 999999; // @TODO this could be a configurable option
 }
 
 /**
@@ -415,46 +447,47 @@ function custom_max_async_feed_attempts( $max_attempts ) {
  *
  * @return array
  */
-function webhooks_request_data( $request_data, $feed, $entry, $form ) {
-	// Form hooks don't seem to be called during webform request, so do it ourselves
-	$form = do_civicrm_replacement( $form, 'webhook_request_data' );
+function webhooks_request_data($request_data, $feed, $entry, $form)
+{
+  // Form hooks don't seem to be called during webform request, so do it ourselves
+  $form = do_civicrm_replacement($form, 'webhook_request_data');
 
-	if ( $feed['meta']['requestFormat'] === 'json' ) {
-		$rewrite_data = [];
+  if ($feed['meta']['requestFormat'] === 'json') {
+    $rewrite_data = array();
 
-		$multi_json = (bool) FieldsAddOn::get_instance()->get_plugin_setting( 'civicrm_multi_json' );
+    $multi_json = (bool) FieldsAddOn::get_instance()->get_plugin_setting('civicrm_multi_json');
 
-		/** @var \GF_Field $field */
-		foreach ( $form['fields'] as $field ) {
-			if ( property_exists( $field, 'storageType' ) && $field->storageType == 'json' ) {
-				$rewrite_data[ $field['id'] ] = json_decode( $entry[ $field['id'] ] );
-			} elseif (
-				! empty( $multi_json ) &&  // JSON encoding selected in settings
-				( is_a( $field, 'GF_Field_Checkbox' ) || is_a( $field, 'GF_Field_MultiSelect' ) ) // Multi-value field
-			) {
-				$rewrite_data[ $field->id ] = fix_multi_values( $field, $entry );
-			}
+    /** @var \GF_Field $field */
+    foreach ($form['fields'] as $field) {
+      if (property_exists($field, 'storageType') && $field->storageType == 'json') {
+        $rewrite_data[$field['id']] = json_decode($entry[$field['id']]);
+      } elseif (
+        ! empty($multi_json)  // JSON encoding selected in settings
+        && (is_a($field, 'GF_Field_Checkbox') || is_a($field, 'GF_Field_MultiSelect')) // Multi-value field
+      ) {
+        $rewrite_data[$field->id] = fix_multi_values($field, $entry);
+      }
 
-			/*
-			* Custom Price, Product fields send the value in $ 50.00 format which is problematic
-			* @TODO If the $feed['meta']['fieldValues'][x] field has a value=gf_custom then custom_value will contain something like {membership_type:83:price} - this requires new logic extract the field ID. Will not contain the usual field ID.
-			*/
+      /*
+            * Custom Price, Product fields send the value in $ 50.00 format which is problematic
+            * @TODO If the $feed['meta']['fieldValues'][x] field has a value=gf_custom then custom_value will contain something like {membership_type:83:price} - this requires new logic extract the field ID. Will not contain the usual field ID.
+            */
 
-			if ( is_a( $field, 'GF_Field_Price' ) && $field->inputType == 'price' && isset( $entry[ $field->id ] ) ) {
-				$rewrite_data[ $field->id ] = convertInternationalCurrencyToFloat( $entry[ $field->id ] );
-			}
-		}
-		foreach ( $feed['meta']['fieldValues'] as $field_value ) {
-			if ( ( ! empty( $field_value['custom_key'] ) ) && ( $value = $rewrite_data[ $field_value['value'] ] ?? NULL ) ) {
-				$request_data[ $field_value['custom_key'] ] = $value;
-			}
-		}
-	}
+      if (is_a($field, 'GF_Field_Price') && $field->inputType == 'price' && isset($entry[$field->id])) {
+        $rewrite_data[$field->id] = convertInternationalCurrencyToFloat($entry[$field->id]);
+      }
+    }
+    foreach ($feed['meta']['fieldValues'] as $field_value) {
+      if ((! empty($field_value['custom_key'])) && ($value = $rewrite_data[$field_value['value']] ?? null)) {
+        $request_data[$field_value['custom_key']] = $value;
+      }
+    }
+  }
 
-	return $request_data;
+  return $request_data;
 }
 
-add_filter( 'gform_webhooks_request_data', 'GFCiviCRM\webhooks_request_data', 10, 4 );
+add_filter('gform_webhooks_request_data', 'GFCiviCRM\webhooks_request_data', 10, 4);
 
 /**
  * Add setting for CiviCRM Source to Gravity Forms editor standard settings
@@ -465,186 +498,204 @@ add_filter( 'gform_webhooks_request_data', 'GFCiviCRM\webhooks_request_data', 10
  * @throws \API_Exception
  * @throws \Civi\API\Exception\UnauthorizedException
  */
-function civicrm_optiongroup_setting( $position, $form_id ) {
-	$profile_name = get_rest_connection_profile( $form_id );
+function civicrm_optiongroup_setting($position, $form_id)
+{
+  $profile_name = get_rest_connection_profile($form_id);
 
-	// Check if a CiviCRM installation exists
-	if ( check_civicrm_installation()['is_error'] ) {
-		return;
-	}
+  // Check if a CiviCRM installation exists
+  if (check_civicrm_installation()['is_error']) {
+    return;
+  }
 
-	switch ( $position ) {
-		case BEFORE_CHOICES_SETTING:
-			$api_params = [
-				'return' => ['name', 'title'], // Specify the fields to return
-			];
-			$api_options = [
-				'check_permissions' => 0, // Set check_permissions to false
-				'sort' 				=> 'title ASC',
-				'limit'				=> 0,
-			];
-			$option_groups = api_wrapper( $profile_name, 'OptionGroup', 'get', $api_params, $api_options ) ?? [];
+  switch ($position) {
+    case BEFORE_CHOICES_SETTING:
+      $api_params    = array(
+        'return' => array('name', 'title'), // Specify the fields to return
+      );
+      $api_options   = array(
+        'check_permissions' => 0, // Set check_permissions to false
+        'sort'              => 'title ASC',
+        'limit'             => 0,
+      );
+      $option_groups = api_wrapper($profile_name, 'OptionGroup', 'get', $api_params, $api_options) ?? array();
 
-			try {
-				$form_processors = api_wrapper($profile_name, 'FormProcessorInstance', 'get', [ 'sequential' => 1], [ 'limit' => 0]) ?? [];
+      try {
+        $form_processors = api_wrapper($profile_name, 'FormProcessorInstance', 'get', array('sequential' => 1), array('limit' => 0)) ?? array();
 
-				$form_processors = array_filter( array_map( function ( $processor ) use ( $option_groups ) {
-					$mapped = [
-						'name'    => $processor['name'],
-						'title'   => $processor['title'],
-						'options' => [],
-					];
+        $form_processors = array_filter(
+          array_map(
+            function ($processor) use ($option_groups) {
+              $mapped = array(
+                'name'    => $processor['name'],
+                'title'   => $processor['title'],
+                'options' => array(),
+              );
 
-					foreach ( $processor['inputs'] as $input ) {
-						$type = &$input['type']['name'];
+              foreach ($processor['inputs'] as $input) {
+                $type = &$input['type']['name'];
 
-						if ( in_array( $type, [
-							'OptionGroup',
-							'CustomOptionListType',
-							'YesNoOptionList',
-							'MailingGroup',
-							'Tag',
-						] ) ) {
-							$mapped['options'][ $input['name'] ] = $input['title'];
-						}
-					}
+                if (
+                  in_array(
+                    $type,
+                    array(
+                      'OptionGroup',
+                      'CustomOptionListType',
+                      'YesNoOptionList',
+                      'MailingGroup',
+                      'Tag',
+                    )
+                  )
+                ) {
+                  $mapped['options'][$input['name']] = $input['title'];
+                }
+              }
 
-					return ! empty( $mapped['options'] ) ? $mapped : FALSE;
-				}, $form_processors ) );
-			} catch ( CRM_Core_Exception $e ) {
-				// Form processor extension may not be installed, ignore
-				$form_processors = [];
-			}
-			?>
-			<li class="civicrm_optiongroup_setting field_setting">
-				<label for="civicrm_optiongroup_selector">
-					<?php esc_html_e( 'CiviCRM Source', 'gf-civicrm' ); ?>
-				</label>
-				<select id="civicrm_optiongroup_selector"
-				        onchange="SetCiviCRMOptionGroup(this)">
-					<option value=""><?php esc_html_e( 'None' ); ?></option>
-					<?php foreach ( $form_processors as $processor ): ?>
-						<optgroup label="Form Processor: <?php echo $processor['title']; ?>">
-							<?php foreach ( $processor['options'] as $pr_name => $pr_title ) {
-								echo "<option value=\"civicrm_fp__{$processor['name']}__{$pr_name}\">{$pr_title}</option>";
-							} ?>
-						</optgroup>
-					<?php endforeach; ?>
-					<optgroup label="Option Groups">
-						<?php foreach ( $option_groups as $group ) {
-							echo "<option value=\"civicrm__{$group['name']}\">" . sprintf( __( '%1$s (ID: %2$u)', 'gf-civicrm' ), $group['title'], $group['id'] ) . "</option>";
-						} ?>
-					</optgroup>
-				</select>
-			</li>
-			<?php
-			break;
-	}
+              return ! empty($mapped['options']) ? $mapped : false;
+            },
+            $form_processors
+          )
+        );
+      } catch (CRM_Core_Exception $e) {
+        // Form processor extension may not be installed, ignore
+        $form_processors = array();
+      }
+?>
+      <li class="civicrm_optiongroup_setting field_setting">
+        <label for="civicrm_optiongroup_selector">
+          <?php esc_html_e('CiviCRM Source', 'gf-civicrm'); ?>
+        </label>
+        <select id="civicrm_optiongroup_selector"
+          onchange="SetCiviCRMOptionGroup(this)">
+          <option value=""><?php esc_html_e('None'); ?></option>
+          <?php foreach ($form_processors as $processor) : ?>
+            <optgroup label="Form Processor: <?php echo $processor['title']; ?>">
+              <?php
+              foreach ($processor['options'] as $pr_name => $pr_title) {
+                echo "<option value=\"civicrm_fp__{$processor['name']}__{$pr_name}\">{$pr_title}</option>";
+              }
+              ?>
+            </optgroup>
+          <?php endforeach; ?>
+          <optgroup label="Option Groups">
+            <?php
+            foreach ($option_groups as $group) {
+              echo "<option value=\"civicrm__{$group['name']}\">" . sprintf(__('%1$s (ID: %2$u)', 'gf-civicrm'), $group['title'], $group['id']) . '</option>';
+            }
+            ?>
+          </optgroup>
+        </select>
+      </li>
+  <?php
+      break;
+  }
 }
 
-add_action( 'gform_field_standard_settings', 'GFCiviCRM\civicrm_optiongroup_setting', 10, 2 );
+add_action('gform_field_standard_settings', 'GFCiviCRM\civicrm_optiongroup_setting', 10, 2);
 
 /**
  * Embed javascript to save the selected CiviCRM Source option.
  */
-function editor_script() {
-	?>
-	<script src="<?= plugin_dir_url( __FILE__ ) . 'js/gf-civicrm-merge-tags.js?ver=' . GF_CIVICRM_FIELDS_ADDON_VERSION; ?>"></script>
-	<script src="<?= plugin_dir_url( __FILE__ ) . 'js/gf-civicrm-fields.js?ver=' . GF_CIVICRM_FIELDS_ADDON_VERSION; ?>"></script>
+function editor_script()
+{
+  ?>
+  <script src="<?php echo plugin_dir_url(__FILE__) . 'js/gf-civicrm-merge-tags.js?ver=' . GF_CIVICRM_FIELDS_ADDON_VERSION; ?>"></script>
+  <script src="<?php echo plugin_dir_url(__FILE__) . 'js/gf-civicrm-fields.js?ver=' . GF_CIVICRM_FIELDS_ADDON_VERSION; ?>"></script>
 
-	<script type="text/javascript">
-      for (let field of ['select', 'multiselect', 'checkbox', 'radio']) {
-        fieldSettings[field] += ', .civicrm_optiongroup_setting'
+  <script type="text/javascript">
+    for (let field of ['select', 'multiselect', 'checkbox', 'radio']) {
+      fieldSettings[field] += ', .civicrm_optiongroup_setting'
+    }
+
+    jQuery(document).bind('gform_load_field_settings', function(event, field) {
+      jQuery('#civicrm_optiongroup_selector').val(field.civicrmOptionGroup)
+    })
+
+    function SetCiviCRMOptionGroup({
+      value
+    }) {
+      SetFieldProperty('civicrmOptionGroup', value);
+    }
+
+    jQuery(document).ready(function($) {
+      // Enable display of the default value field for these other field types
+      $(document).on('gform_load_field_settings', function(event, field, form) {
+        if (field.inputType === 'radio' || field.inputType === 'multiselect' || field.inputType === 'checkbox') {
+          $('.default_value_setting').show();
+          $('#field_default_value').val(field.defaultValue);
+        }
+      });
+      // Add default value, comma separated values help text
+      $(document).bind('gform_load_field_settings', function(event, field, form) {
+        // Check for specific field types or all types
+        if (field.type === 'multiselect' || field.type === 'checkbox') {
+          // Locate the default value setting field
+          var defaultValueSetting = $('.field_setting:contains("Default Value")');
+
+          // Check if the help text is already added
+          if (!defaultValueSetting.find('.custom-help-text').length) {
+            // Append the help text
+            defaultValueSetting.append('<p class="custom-help-text description">Enter comma-separated values for default selections.</p>');
+          }
+        }
+      });
+
+      // Hide all choice labels for checkbox fields, feature is replaced by the default value field
+      function updateChoiceLabelDisplay() {
+        $('.field-choice-label').css('display', 'none');
       }
 
-      jQuery(document).bind('gform_load_field_settings', function (event, field) {
-        jQuery('#civicrm_optiongroup_selector').val(field.civicrmOptionGroup)
-      })
+      // Run when the form editor is initially loaded
+      updateChoiceLabelDisplay();
 
-      function SetCiviCRMOptionGroup({value}) {
-        SetFieldProperty('civicrmOptionGroup', value);
+      // Bind to the event that triggers when field settings are loaded/changed
+      $(document).bind('gform_load_field_settings', function() {
+        updateChoiceLabelDisplay();
+      });
+
+
+      function handleEditChoicesVisibility(selector) {
+        // Get the selected option value
+        var selectedValue = $(selector).val();
+
+        // Show/Hide the Edit Choices field depending on the CiviCRM Source field value
+        if (selectedValue === '') {
+          $('.choices-ui__trigger-section').show();
+        } else {
+          $('.choices-ui__trigger-section').hide();
+        }
       }
 
-	  jQuery(document).ready(function($) {
-            // Enable display of the default value field for these other field types
-            $(document).on('gform_load_field_settings', function(event, field, form) {
-                if (field.inputType === 'radio' || field.inputType === 'multiselect' || field.inputType === 'checkbox') {
-                    $('.default_value_setting').show();
-                    $('#field_default_value').val(field.defaultValue);
-                }
-            });
-			// Add default value, comma separated values help text
-			$(document).bind('gform_load_field_settings', function(event, field, form) {
-                // Check for specific field types or all types
-                if (field.type === 'multiselect' || field.type === 'checkbox') {
-                    // Locate the default value setting field
-                    var defaultValueSetting = $('.field_setting:contains("Default Value")');
+      // Target the select element
+      $('#civicrm_optiongroup_selector').on('change', function() {
+        handleEditChoicesVisibility('#civicrm_optiongroup_selector')
+      });
 
-                    // Check if the help text is already added
-                    if (!defaultValueSetting.find('.custom-help-text').length) {
-                        // Append the help text
-                        defaultValueSetting.append('<p class="custom-help-text description">Enter comma-separated values for default selections.</p>');
-                    }
-                }
-            });
-
-			// Hide all choice labels for checkbox fields, feature is replaced by the default value field
-			function updateChoiceLabelDisplay() {
-                $('.field-choice-label').css('display', 'none');
-            }
-
-            // Run when the form editor is initially loaded
-            updateChoiceLabelDisplay();
-
-            // Bind to the event that triggers when field settings are loaded/changed
-            $(document).bind('gform_load_field_settings', function() {
-                updateChoiceLabelDisplay();
-            });
-
-
-			function handleEditChoicesVisibility(selector) {
-				// Get the selected option value
-				var selectedValue = $(selector).val();
-
-				// Show/Hide the Edit Choices field depending on the CiviCRM Source field value
-				if (selectedValue === '') {
-					$('.choices-ui__trigger-section').show();
-				} else {
-					$('.choices-ui__trigger-section').hide();
-				}
-			}
-
-			// Target the select element
-			$('#civicrm_optiongroup_selector').on('change', function() {
-				handleEditChoicesVisibility('#civicrm_optiongroup_selector')
-			});
-
-			// MutationObserver to detect visibility changes
-			var observer = new MutationObserver(function(mutationsList) {
-				mutationsList.forEach(function(mutation) {
-					// Check if the CiviCRM Sources field is now visible and handle the change
-					if ($('#civicrm_optiongroup_selector').is(':visible')) {
-						handleEditChoicesVisibility('#civicrm_optiongroup_selector')
-					}
-				});
-			});
-
-			// Start observing the select element for visibility changes
-			var targetNode = document.getElementById('general_tab');
-			// Configuration of the observer
-			var config = {
-				attributes: true,      // Monitor changes to attributes
-				childList: true,       // Monitor changes to child nodes
-				subtree: true,         // Monitor changes in the entire subtree
-				characterData: true    // Monitor changes to text nodes
-			};
-			observer.observe(targetNode, config);
+      // MutationObserver to detect visibility changes
+      var observer = new MutationObserver(function(mutationsList) {
+        mutationsList.forEach(function(mutation) {
+          // Check if the CiviCRM Sources field is now visible and handle the change
+          if ($('#civicrm_optiongroup_selector').is(':visible')) {
+            handleEditChoicesVisibility('#civicrm_optiongroup_selector')
+          }
         });
-	</script>
-	<?php
+      });
+
+      // Start observing the select element for visibility changes
+      var targetNode = document.getElementById('general_tab');
+      // Configuration of the observer
+      var config = {
+        attributes: true, // Monitor changes to attributes
+        childList: true, // Monitor changes to child nodes
+        subtree: true, // Monitor changes in the entire subtree
+        characterData: true // Monitor changes to text nodes
+      };
+      observer.observe(targetNode, config);
+    });
+  </script>
+<?php
 }
 
-add_action( 'gform_editor_js', 'GFCiviCRM\editor_script', 11, 0 );
+add_action('gform_editor_js', 'GFCiviCRM\editor_script', 11, 0);
 
 /**
  * Replacement callback for GFCiviCRM\replace_merge_tags()
@@ -653,153 +704,144 @@ add_action( 'gform_editor_js', 'GFCiviCRM\editor_script', 11, 0 );
  *
  * @return string
  */
-function fp_tag_default( $matches, $fallback = '', $multiple = FALSE ) {
-	static $defaults = [];
+function fp_tag_default($matches, $fallback = '', $multiple = false)
+{
+  static $defaults = array();
 
-	$result = $fallback;
-	[ , $processor, $field ] = $matches;
+  $result                = $fallback;
+  [, $processor, $field] = $matches;
 
-	// Check if a CiviCRM installation exists
-	if ( check_civicrm_installation()['is_error'] ) {
-		return $result;
-	}
+  // Check if a CiviCRM installation exists
+  if (check_civicrm_installation()['is_error']) {
+    return $result;
+  }
 
-	$profile_name = get_rest_connection_profile();
+  $profile_name = get_rest_connection_profile();
 
-	if ( ! isset( $defaults[ $processor ] ) ) {
-		try {
-			$api_params = array(
-				'api_action' => $processor,
-			);
-			$api_options = array(
-				'check_permissions' => 1, // Set check_permissions to false
-				'limit'	=> 0,
-				'cache' => NULL,
-			);
+  if (! isset($defaults[$processor])) {
+    try {
+      $api_params  = array(
+        'api_action' => $processor,
+      );
+      $api_options = array(
+        'check_permissions' => 1, // Set check_permissions to false
+        'limit'             => 0,
+        'cache'             => null,
+      );
 
-			// Get the form processor fields
-			$fields = api_wrapper( $profile_name, 'FormProcessorDefaults', 'getfields', $api_params, $api_options );
+      // Get the form processor fields
+      $fields = api_wrapper($profile_name, 'FormProcessorDefaults', 'getfields', $api_params, $api_options);
 
-			foreach ( $fields as $value ) {
-				if ( ! empty( $_GET[ $value['name'] ] ) ) {
-					$api_params[ $value['name'] ] = $_GET[ $value['name'] ];
-				}
-			}
+      foreach ($fields as $value) {
+        if (! empty($_GET[$value['name']])) {
+          $api_params[$value['name']] = $_GET[$value['name']];
+        }
+      }
 
-			// Get field default values
-			$defaults[ $processor ] = api_wrapper( $profile_name, 'FormProcessorDefaults', $processor, $api_params, $api_options );
-		} catch ( CRM_Core_Exception $e ) {
-			$defaults[ $processor ] = FALSE;
-		}
-	}
+      // Get field default values
+      $defaults[$processor] = api_wrapper($profile_name, 'FormProcessorDefaults', $processor, $api_params, $api_options);
+    } catch (CRM_Core_Exception $e) {
+      $defaults[$processor] = false;
+    }
+  }
 
-	if ( $defaults[ $processor ] && array_key_exists( $field, $defaults[ $processor ] ) ) {
-		$result = $defaults[ $processor ][ $field ];
-	}
+  if ($defaults[$processor] && array_key_exists($field, $defaults[$processor])) {
+    $result = $defaults[$processor][$field];
+  }
 
-	if ( $multiple ) {
-		return $result;
-	}
+  if ($multiple) {
+    return $result;
+  }
 
-	// GFCV-20 Resolve to first value if array
-	// @TODO - This may be interferring with the setting of multiple values using the default value field, form process merge tag
-	while ( is_array( $result ) ) {
-		$result = reset( $result );
-	}
+  // GFCV-20 Resolve to first value if array
+  // @TODO - This may be interferring with the setting of multiple values using the default value field, form process merge tag
+  while (is_array($result)) {
+    $result = reset($result);
+  }
 
-	return $result;
+  return $result;
 }
 
 /**
  * Find and replace {civicrm_fp.*}, {gf_civicrm_site_key}, {gf_civicrm_api_key}, and {rest_api_url} merge tags
  *
  * @param string $text
- * @param array $form
- * @param array $entry
- * @param bool $url_encode
- * @param bool $esc_html
- * @param bool $nl2br
+ * @param array  $form
+ * @param array  $entry
+ * @param bool   $url_encode
+ * @param bool   $esc_html
+ * @param bool   $nl2br
  * @param string $format
  *
  * @return string
  */
-function replace_merge_tags( $text, $form, $entry, $url_encode, $esc_html, $nl2br, $format ) {
-	$gf_civicrm_site_key_merge_tag     = '{gf_civicrm_site_key}';
-	$gf_civicrm_api_key_merge_tag      = '{gf_civicrm_api_key}';
-	$gf_civicrm_rest_api_url_merge_tag = '{rest_api_url}';
-	$needs_site_key = strpos( $text, $gf_civicrm_site_key_merge_tag ) !== false;
-	$needs_api_key  = strpos( $text, $gf_civicrm_api_key_merge_tag ) !== false;
-	$needs_api_url  = strpos( $text, $gf_civicrm_rest_api_url_merge_tag ) !== false;
+function replace_merge_tags($text, $form, $entry, $url_encode, $esc_html, $nl2br, $format)
+{
+  $gf_civicrm_site_key_merge_tag = '{gf_civicrm_site_key}';
+  $gf_civicrm_api_key_merge_tag  = '{gf_civicrm_api_key}';
+  $needs_site_key                = strpos($text, $gf_civicrm_site_key_merge_tag) !== false;
+  $needs_api_key                 = strpos($text, $gf_civicrm_api_key_merge_tag) !== false;
 
-	if ( $needs_site_key || $needs_api_key || $needs_api_url ) {
-		// Only call these once if needed
-		$profile_name = get_rest_connection_profile();
-		$profiles     = get_profiles();
-		$plugin_active = is_plugin_active( 'connector-civicrm-mcrestface/wpcmrf.php' );
-		$use_mcrf      = boolval( rgars( $form, 'gf-civicrm/civicrm_use_mcrf' ) );
+  if ($needs_site_key || $needs_api_key) {
+    // Only call these once if needed
+    $profile_name  = get_rest_connection_profile();
+    $profiles      = get_profiles();
+    $plugin_active = is_plugin_active('connector-civicrm-mcrestface/wpcmrf.php');
 
-		if ( $plugin_active && isset( $profiles[ $profile_name ] ) ) {
-			$profile = $profiles[ $profile_name ];
-		} else {
-			$profile = null;
-		}
+    if ($plugin_active && isset($profiles[$profile_name])) {
+      $profile = $profiles[$profile_name];
+    } else {
+      $profile = null;
+    }
 
-		if ( $needs_site_key ) {
-			$gf_civicrm_site_key = $profile ? $profile['site_key'] : FieldsAddOn::get_instance()->get_plugin_setting( 'gf_civicrm_site_key' );
-			$text = str_replace( $gf_civicrm_site_key_merge_tag, $gf_civicrm_site_key, $text );
-		}
+    if ($needs_site_key) {
+      $gf_civicrm_site_key = $profile ? $profile['site_key'] : FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_site_key');
+      $text                = str_replace($gf_civicrm_site_key_merge_tag, $gf_civicrm_site_key, $text);
+    }
 
-		if ( $needs_api_key ) {
-			$gf_civicrm_api_key = $profile ? $profile['api_key'] : FieldsAddOn::get_instance()->get_plugin_setting( 'gf_civicrm_api_key' );
-			$text = str_replace( $gf_civicrm_api_key_merge_tag, $gf_civicrm_api_key, $text );
-		}
+    if ($needs_api_key) {
+      $gf_civicrm_api_key = $profile ? $profile['api_key'] : FieldsAddOn::get_instance()->get_plugin_setting('gf_civicrm_api_key');
+      $text               = str_replace($gf_civicrm_api_key_merge_tag, $gf_civicrm_api_key, $text);
+    }
+  }
 
-		if ( $needs_api_url && $use_mcrf ) {
-			$form_profile_name = rgars( $form, 'gf-civicrm/civicrm_rest_connection' );
-			if ( 'default' !== $form_profile_name && isset( $profiles[$form_profile_name] ) ) {
-				$profile = $profiles[$form_profile_name];
-			}
-			$gf_civicrm_api_url = $profile ? ( ( ! is_array( $profile['function'] ) && 'GFCiviCRM\gf_civicrm_wpcmrf_api' === $profile['function'] ) ? $profile['url'] : $gf_civicrm_rest_api_url_merge_tag ) : $gf_civicrm_rest_api_url_merge_tag;
-			$text = str_replace( $gf_civicrm_rest_api_url_merge_tag, $gf_civicrm_api_url, $text );
-		}
-	}
+  // TODO - This may pass in multiple options
+  /*
+    return preg_replace_callback(
+        '{ {civicrm_fp(?:_default)? \. ([[:alnum:]_]+) \. ([[:alnum:]_]+) } }x',
+        'GFCiviCRM\fp_tag_default',
+        $text,'',true
 
-	// TODO - This may pass in multiple options
-	/*
-	return preg_replace_callback(
-		'{ {civicrm_fp(?:_default)? \. ([[:alnum:]_]+) \. ([[:alnum:]_]+) } }x',
-		'GFCiviCRM\fp_tag_default',
-		$text,'',true
-
-	);
-	*/
-	$text = preg_replace_callback(
-		'{ {civicrm_fp(?:_default)? \. ([[:alnum:]_]+) \. ([[:alnum:]_]+) } }x',
-		'GFCiviCRM\fp_tag_default',
-		$text
-	);
-	return $text;
+    );
+    */
+  $text = preg_replace_callback(
+    '{ {civicrm_fp(?:_default)? \. ([[:alnum:]_]+) \. ([[:alnum:]_]+) } }x',
+    'GFCiviCRM\fp_tag_default',
+    $text
+  );
+  return $text;
 }
 
-add_filter( 'gform_custom_merge_tags', 'GFCiviCRM\compose_merge_tags', 10, 1 );
+add_filter('gform_custom_merge_tags', 'GFCiviCRM\compose_merge_tags', 10, 1);
 
-add_filter( 'gform_pre_replace_merge_tags', 'GFCiviCRM\replace_merge_tags', 9, 7 );
+add_filter('gform_pre_replace_merge_tags', 'GFCiviCRM\replace_merge_tags', 9, 7);
 
-define( 'GF_CIVICRM_FIELDS_ADDON_VERSION', get_file_data( __FILE__, [ 'Version' => 'Version' ] )['Version'] );
+define('GF_CIVICRM_FIELDS_ADDON_VERSION', get_file_data(__FILE__, array('Version' => 'Version'))['Version']);
 
-add_action( 'gform_loaded', 'GFCiviCRM\addon_bootstrap', 5 );
+add_action('gform_loaded', 'GFCiviCRM\addon_bootstrap', 5);
 
-function addon_bootstrap() {
+function addon_bootstrap()
+{
 
-	if ( ! method_exists( 'GFForms', 'include_addon_framework' ) ) {
-		return;
-	}
+  if (! method_exists('GFForms', 'include_addon_framework')) {
+    return;
+  }
 
-	require_once( 'class-gf-civicrm-fields.php' );
-    require_once( 'includes/class-gf-civicrm-export-addon.php' );
+  require_once 'class-gf-civicrm-fields.php';
+  require_once 'includes/class-gf-civicrm-export-addon.php';
 
-	GFAddOn::register( 'GFCiviCRM\FieldsAddOn' );
-    GFAddOn::register( 'GFCiviCRM\ExportAddOn' );
+  GFAddOn::register('GFCiviCRM\FieldsAddOn');
+  GFAddOn::register('GFCiviCRM\ExportAddOn');
 }
 
 /**
@@ -807,297 +849,305 @@ function addon_bootstrap() {
  *
  * GFCV-89
  */
-add_filter( 'gform_counter_script', 'GFCiviCRM\set_text_input_counter', 10, 5 );
-function set_text_input_counter( $script, $form_id, $input_id, $max_length, $field ) {
-	if ($max_length > 255) {
-		$max_length = 255;
-	}
+add_filter('gform_counter_script', 'GFCiviCRM\set_text_input_counter', 10, 5);
+function set_text_input_counter($script, $form_id, $input_id, $max_length, $field)
+{
+  if ($max_length > 255) {
+    $max_length = 255;
+  }
 
-    $displayFormat = esc_js( __( '#input of #max max characters', 'gravityforms' ) );
+  $displayFormat = esc_js(__('#input of #max max characters', 'gravityforms'));
 
-    $script = <<<EOJS
-		if(!jQuery('#{$input_id}+.ginput_counter').length){
-			jQuery('#{$input_id}').textareaCount({
-		    	'maxCharacterSize': {$max_length},
-		    	'originalStyle': 'ginput_counter gfield_description',
-		    	'displayFormat' : '{$displayFormat}'
-		    });
-		    jQuery('#{$input_id}').next('.ginput_counter').attr('aria-live','polite');
-		};
-	EOJS;
-    return $script;
+  $script = <<<EOJS
+    if(!jQuery('#{$input_id}+.ginput_counter').length){
+      jQuery('#{$input_id}').textareaCount({
+          'maxCharacterSize': {$max_length},
+          'originalStyle': 'ginput_counter gfield_description',
+          'displayFormat' : '{$displayFormat}'
+        });
+        jQuery('#{$input_id}').next('.ginput_counter').attr('aria-live','polite');
+    };
+    EOJS;
+  return $script;
 }
 
 /**
  * Replace the default countries list with CiviCRM's list.
  *
  * @param array $choices
- *
  */
-add_filter( 'gform_countries', 'GFCiviCRM\address_replace_countries_list' );
-function address_replace_countries_list( $choices ) {
-	$replace = [];
-	$countries = [];
+add_filter('gform_countries', 'GFCiviCRM\address_replace_countries_list');
+function address_replace_countries_list($choices)
+{
+  $replace   = array();
+  $countries = array();
 
-	if ( $cached_countries_data = get_transient( 'gfcv_civicrm_countries' ) ) {
-		$countries = $cached_countries_data;
-	} else {
-		try {
-			/**
-			 * DEV NOTE: This is also done in loadCountriesAndStatesData().
-			 * TODO: Reduce duplication and pull data from CiviCRM outside of GFCiviCRM::Address_Field.
-			 */
-			$profile_name = get_rest_connection_profile();
+  if ($cached_countries_data = get_transient('gfcv_civicrm_countries')) {
+    $countries = $cached_countries_data;
+  } else {
+    try {
+      /**
+       * DEV NOTE: This is also done in loadCountriesAndStatesData().
+       * TODO: Reduce duplication and pull data from CiviCRM outside of GFCiviCRM::Address_Field.
+       */
+      $profile_name = get_rest_connection_profile();
 
-			// Get the list of available countries configured in CiviCRM Settings
-			$api_params = [
-				'return' => [ 'countryLimit' ],
-			];
-			$api_options = [
-				'check_permissions' => 0, // Set check_permissions to false
-				'limit' => 0,
-			];
-			$available_countries = api_wrapper( $profile_name, 'Setting', 'get', $api_params, $api_options );
-			$available_countries = reset($available_countries);
+      // Get the list of available countries configured in CiviCRM Settings
+      $api_params          = array(
+        'return' => array('countryLimit'),
+      );
+      $api_options         = array(
+        'check_permissions' => 0, // Set check_permissions to false
+        'limit'             => 0,
+      );
+      $available_countries = api_wrapper($profile_name, 'Setting', 'get', $api_params, $api_options);
+      $available_countries = reset($available_countries);
 
-			$api_params = [
-				'select' => [ 'id', 'name', 'iso_code' ],
-				'api.StateProvince.get' => [
-					'options' => ['limit' => 0, 'sort' => "name ASC"],
-				],
-				'options' => ['limit' => 0, 'sort' => "name ASC"],
-			];
-			if ( !empty( $available_countries['countryLimit'] ) ) {
-				$api_params['id'] = [ 'IN' => $available_countries['countryLimit'] ];
-			}
-			$api_options = [
-				'check_permissions' => 0, // Set check_permissions to false
-				'limit' => 0,
-			];
+      $api_params = array(
+        'select'                => array('id', 'name', 'iso_code'),
+        'api.StateProvince.get' => array(
+          'options' => array(
+            'limit' => 0,
+            'sort'  => 'name ASC',
+          ),
+        ),
+        'options'               => array(
+          'limit' => 0,
+          'sort'  => 'name ASC',
+        ),
+      );
+      if (! empty($available_countries['countryLimit'])) {
+        $api_params['id'] = array('IN' => $available_countries['countryLimit']);
+      }
+      $api_options = array(
+        'check_permissions' => 0, // Set check_permissions to false
+        'limit'             => 0,
+      );
 
-			// Get Countries and their States/Provinces from CiviCRM
-			$countries_data = api_wrapper( $profile_name, 'Country', 'get', $api_params, $api_options );
+      // Get Countries and their States/Provinces from CiviCRM
+      $countries_data = api_wrapper($profile_name, 'Country', 'get', $api_params, $api_options);
 
-			if ( !empty( $countries_data ) ) {
-				foreach ( $countries_data as $country ) {
-					$state_province = $country['api.StateProvince.get']['values'] ?? [];
-					$country['states'] = $state_province;
-					unset($country['api.StateProvince.get']);
+      if (! empty($countries_data)) {
+        foreach ($countries_data as $country) {
+          $state_province    = $country['api.StateProvince.get']['values'] ?? array();
+          $country['states'] = $state_province;
+          unset($country['api.StateProvince.get']);
 
-					$countries[] = $country;
-				}
+          $countries[] = $country;
+        }
 
-				set_transient( 'gfcv_civicrm_countries', $countries );
-			}
-		} catch ( \CRM_Core_Exception $e ) {
-			// Could not retrieve CiviCRM countries list
-			// Fallback to the original set of choices
-		}
-	}
+        set_transient('gfcv_civicrm_countries', $countries);
+      }
+    } catch (\CRM_Core_Exception $e) {
+      // Could not retrieve CiviCRM countries list
+      // Fallback to the original set of choices
+    }
+  }
 
-	if ( !empty( $countries ) ) {
-		foreach ($countries as $country) {
-			$replace[] = __( $country["name"], 'gf-civicrm-formprocessor' );
-		}
-		return $replace;
-	}
+  if (! empty($countries)) {
+    foreach ($countries as $country) {
+      $replace[] = __($country['name'], 'gf-civicrm-formprocessor');
+    }
+    return $replace;
+  }
 
-	return $choices;
+  return $choices;
 }
 
 /**
  * Replace dropdown field null values with blank "" on submission.
  */
-add_action( 'gform_pre_submission', 'GFCiviCRM\handle_optional_select_field_values' );
-function handle_optional_select_field_values( $form ) {
-	// Get the input id for multi select type fields
-	$fields = $form['fields'];
+add_action('gform_pre_submission', 'GFCiviCRM\handle_optional_select_field_values');
+function handle_optional_select_field_values($form)
+{
+  // Get the input id for multi select type fields
+  $fields = $form['fields'];
 
-	foreach ($fields as $field) {
-		if ( 'select' === $field->inputType ) {
-			$field_id = $field->id;
-			$value = $_POST['input_' . $field_id];
+  foreach ($fields as $field) {
+    if ('select' === $field->inputType) {
+      $field_id = $field->id;
+      $value    = $_POST['input_' . $field_id];
 
-			// Fix optional dropdown fields saving no selection as "- None -"
-			if ( $value == "- None -" ) {
-				$_POST['input_' . $field_id] = "";
-			}
-		}
-	}
+      // Fix optional dropdown fields saving no selection as "- None -"
+      if ($value == '- None -') {
+        $_POST['input_' . $field_id] = '';
+      }
+    }
+  }
 }
 
-// Ensure that other WordPress plugins have not lowered the curl timeout which impacts Gravity Forms webhook requests
-function webhooks_request_args( $request_args, $feed, $entry, $form ) {
-    // Set timeout to 10 seconds
-	$request_args['timeout'] = 10000;
+function validateChecksumFromURL($cid_param = 'cid', $cs_param = 'cs'): int|null
+{
+  $contact_id = rgget($cid_param);
+  $checksum   = rgget($cs_param);
 
-	return $request_args;
+  if (empty($contact_id) || empty($checksum)) {
+    return null;
+  }
+
+  try {
+    $profile_name = get_rest_connection_profile();
+
+    // Get Payment Processors from CiviCRM
+    $api_params = array(
+      'id'       => $contact_id,
+      'checksum' => $checksum,
+    );
+    $validator  = api_wrapper($profile_name, 'ContactChecksum', 'validate', $api_params);
+
+    if (! $validator[1][0]) { // checksum validation value
+      throw new \CRM_Core_Exception('Invalid checksum');
+    }
+  } catch (\CRM_Core_Exception $e) {
+    // TODO Log error?
+  }
+
+  return $contact_id;
 }
 
-function validateChecksumFromURL( $cid_param = 'cid', $cs_param = 'cs' ): int|null {
-	$contact_id = rgget( $cid_param );
-	$checksum   = rgget( $cs_param );
+add_action(
+  'admin_notices',
+  function () {
+    if (class_exists('GFAPI') && class_exists('GFCiviCRM\FieldsAddOn')) {
+      echo FieldsAddOn::get_instance()->warn_auth_checksum();
+    }
+  }
+);
 
-	if ( empty( $contact_id ) || empty( $checksum ) ) {
-		return NULL;
-	}
+add_action(
+  'gform_admin_error_messages',
+  function ($messages) {
+    if (class_exists('GFCiviCRM\FieldsAddOn')) {
+      $message = FieldsAddOn::get_instance()->warn_auth_checksum('%s');
+      if ($message) {
+        $messages[] = $message;
+      }
+    }
 
-	try {
-		$profile_name = get_rest_connection_profile();
-
-		// Get Payment Processors from CiviCRM
-		$api_params = [
-			'id' => $contact_id,
-			'checksum' => $checksum ,
-		];
-		$validator = api_wrapper( $profile_name, 'ContactChecksum', 'validate', $api_params );
-
-		if ( ! $validator[1][0] ) { // checksum validation value
-			throw new \CRM_Core_Exception('Invalid checksum');
-		}
-	} catch ( \CRM_Core_Exception $e ) {
-		// TODO Log error?
-	}
-
-	return $contact_id;
-}
-
-add_filter( 'gform_webhooks_request_args', 'GFCiviCRM\webhooks_request_args', 10, 4 );
-
-add_action( 'admin_notices', function() {
-	if ( class_exists( 'GFAPI' ) && class_exists( 'GFCiviCRM\FieldsAddOn' ) ) {
-		echo FieldsAddOn::get_instance()->warn_auth_checksum();
-	}
-} );
-
-add_action( 'gform_admin_error_messages', function( $messages ) {
-	if ( class_exists( 'GFCiviCRM\FieldsAddOn' ) ) {
-		$message = FieldsAddOn::get_instance()->warn_auth_checksum( '%s' );
-		if ( $message ) {
-			$messages[] = $message;
-		}
-	}
-
-	return $messages;
-} );
+    return $messages;
+  }
+);
 
 /**
  * Handles sending webhook alerts for failures to the alerts email address provided in the GF CiviCRM Settings.
  */
-function webhook_alerts( $response, $feed, $entry, $form ) {
-	if ( !class_exists( 'GFCiviCRM\FieldsAddOn' ) ) {
-		return;
-	}
+function webhook_alerts($response, $feed, $entry, $form)
+{
+  if (! class_exists('GFCiviCRM\FieldsAddOn')) {
+    return;
+  }
 
-	// Add the webhook response to the entry meta. Supports multiple feeds.
-	$current_response = gform_get_meta( $entry['id'], 'webhook_feed_response' );
+  // Add the webhook response to the entry meta. Supports multiple feeds.
+  $current_response = gform_get_meta($entry['id'], 'webhook_feed_response');
 
-	$error_code = null;
-	$error_message 	= '';
+  $error_code    = null;
+  $error_message = '';
 
-	// Get the error message, and log it in the Gravity Forms logs (if enabled)
-	if ( is_wp_error( $response ) ) {
-		// If its a WP_Error
-		$error_code = $response->get_error_code();
-        $error_message = $response->get_error_message();
+  // Get the error message, and log it in the Gravity Forms logs (if enabled)
+  if (is_wp_error($response)) {
+    // If its a WP_Error
+    $error_code    = $response->get_error_code();
+    $error_message = $response->get_error_message();
 
-		// Build the webhook response entry content
-		$webhook_feed_response = [
-			'date' => current_datetime(),
-			'body' => $error_message,
-			'response' => $error_code
-		];
+    // Build the webhook response entry content
+    $webhook_feed_response = array(
+      'date'     => current_datetime(),
+      'body'     => $error_message,
+      'response' => $error_code,
+    );
 
-		GFCommon::log_debug( __METHOD__ . '(): WP_Error detected.' );
-	} else {
-		$response_data = $response['body'] ? json_decode($response['body'], true) : '';
+    GFCommon::log_debug(__METHOD__ . '(): WP_Error detected.');
+  } else {
+    $response_data = $response['body'] ? json_decode($response['body'], true) : '';
 
-		// Build the webhook response entry content
-		$webhook_feed_response = [
-			'date' => $response['headers']['data']['date'],
-			'body' => $response_data,
-			'response' => $response['response']
-		];
+    // Build the webhook response entry content
+    $webhook_feed_response = array(
+      'date'     => $response['headers']['data']['date'],
+      'body'     => $response_data,
+      'response' => $response['response'],
+    );
 
-		if ( is_wp_error( $response ) ) {
-			// If its a WP_Error in the webhook feed response
-			$error_code = $response->get_error_code();
-			$error_message = $response->get_error_message();
+    if (is_wp_error($response)) {
+      // If its a WP_Error in the webhook feed response
+      $error_code    = $response->get_error_code();
+      $error_message = $response->get_error_message();
 
-			GFCommon::log_debug( __METHOD__ . '(): WP_Error detected.' );
-		}
+      GFCommon::log_debug(__METHOD__ . '(): WP_Error detected.');
+    }
 
-		if ( isset( $response['response']['code'] ) && $response['response']['code'] >= 300 && strpos( $response['body'], 'is_error' ) == false ) {
-			// If we get an error response
-			$response_data = json_decode( $response['body'], true );
+    if (isset($response['response']['code']) && $response['response']['code'] >= 300 && strpos($response['body'], 'is_error') == false) {
+      // If we get an error response
+      $response_data = json_decode($response['body'], true);
 
-			$error_code = $response['response']['code'];
-			$error_message = $response['response']['message'] . "\n" . ( $response_data['message'] ?? '' );
+      $error_code    = $response['response']['code'];
+      $error_message = $response['response']['message'] . "\n" . ($response_data['message'] ?? '');
 
-			GFCommon::log_debug( __METHOD__ . '(): Error detected.' );
-		}
+      GFCommon::log_debug(__METHOD__ . '(): Error detected.');
+    }
 
-		if ( strpos( $response['body'], 'is_error' ) != false ) {
-			// If is_error appears in the response body
-			// This may happen if the webhook response appears as a success, but the response value from the REST url is actually an error.
+    if (strpos($response['body'], 'is_error') != false) {
+      // If is_error appears in the response body
+      // This may happen if the webhook response appears as a success, but the response value from the REST url is actually an error.
 
-			// Extract the required values
-			$response_data = json_decode( $response['body'], true );
-			$is_error = $response_data['is_error'] ?? false;
+      // Extract the required values
+      $response_data = json_decode($response['body'], true);
+      $is_error      = $response_data['is_error'] ?? false;
 
-			// Validate is_error before doing anything
-			if ( $is_error ) {
-				$error_code = $response_data['error_code'] ?? '';
-				$error_message = $response_data['error_message'] ?? '';
-			}
+      // Validate is_error before doing anything
+      if ($is_error) {
+        $error_code    = $response_data['error_code'] ?? '';
+        $error_message = $response_data['error_message'] ?? '';
+      }
 
-			GFCommon::log_debug( __METHOD__ . '(): Error detected.' );
-		}
-	}
+      GFCommon::log_debug(__METHOD__ . '(): Error detected.');
+    }
+  }
 
-	if ( $current_response ) {
-		$current_response[$feed['id']] = $webhook_feed_response;
-	}
-	gform_update_meta( $entry['id'], 'webhook_feed_response', $current_response );
+  if ($current_response) {
+    $current_response[$feed['id']] = $webhook_feed_response;
+  }
+  gform_update_meta($entry['id'], 'webhook_feed_response', $current_response);
 
-	// Send an alert email if we have an error code
-	if ( $error_code !== null ) {
-		GFCommon::log_debug( __METHOD__ . '(): Error Message: ' . $error_message );
+  // Send an alert email if we have an error code
+  if ($error_code !== null) {
+    GFCommon::log_debug(__METHOD__ . '(): Error Message: ' . $error_message);
 
-		// Do not continue if enable_emails is not true, or if no alerts email has been provided
-		$plugin_settings = FieldsAddOn::get_instance()->get_plugin_settings();
-		if ( !isset($plugin_settings['enable_emails']) || !$plugin_settings['enable_emails'] ||
-			!isset($plugin_settings['gf_civicrm_alerts_email']) || empty($plugin_settings['gf_civicrm_alerts_email']) ) {
-			return;
-		}
+    // Do not continue if enable_emails is not true, or if no alerts email has been provided
+    $plugin_settings = FieldsAddOn::get_instance()->get_plugin_settings();
+    if (
+      ! isset($plugin_settings['enable_emails']) || ! $plugin_settings['enable_emails']
+      || ! isset($plugin_settings['gf_civicrm_alerts_email']) || empty($plugin_settings['gf_civicrm_alerts_email'])
+    ) {
+      return;
+    }
 
-		// Build the alert email
-		$to     		= $plugin_settings['gf_civicrm_alerts_email'];
-		$subject 		= sprintf('Webhook failed on %s', get_site_url());
-		$request_url 	= $feed['meta']['requestURL'];
-		$entry_id 		= $entry['id'];
+    // Build the alert email
+    $to          = $plugin_settings['gf_civicrm_alerts_email'];
+    $subject     = sprintf('Webhook failed on %s', get_site_url());
+    $request_url = $feed['meta']['requestURL'];
+    $entry_id    = $entry['id'];
 
-		$request_url = apply_filters( 'gform_pre_replace_merge_tags', $request_url, $form, $entry, false, false, false, 'html' );
+    $request_url = apply_filters('gform_pre_replace_merge_tags', $request_url, $form, $entry, false, false, false, 'html');
 
-		$body    = sprintf(
-					'Webhook feed on %s failed.' . "\n\n%s%s\n" . 'Feed: "%s" (ID: %s) from form "%s" (ID: %s)' . "\n" . 'Request URL: %s' . "\n" . 'Failed Entry ID: %s',
-					get_site_url(),
-					$error_code ? "Error Code: " . $error_code . "\n": '',
-					$error_message ? "Error: " . $error_message . "\n": '',
-					$feed['meta']['feedName'],
-					$feed['id'],
-					$form['title'],
-					$form['id'],
-					$request_url,
-					$entry_id
-				);
+    $body = sprintf(
+      'Webhook feed on %s failed.' . "\n\n%s%s\n" . 'Feed: "%s" (ID: %s) from form "%s" (ID: %s)' . "\n" . 'Request URL: %s' . "\n" . 'Failed Entry ID: %s',
+      get_site_url(),
+      $error_code ? 'Error Code: ' . $error_code . "\n" : '',
+      $error_message ? 'Error: ' . $error_message . "\n" : '',
+      $feed['meta']['feedName'],
+      $feed['id'],
+      $form['title'],
+      $form['id'],
+      $request_url,
+      $entry_id
+    );
 
-		// Send an email to the nominated alerts email address
-		wp_mail( $to, $subject, $body );
-	}
+    // Send an email to the nominated alerts email address
+    wp_mail($to, $subject, $body);
+  }
 }
 
-add_action( 'gform_webhooks_post_request', 'GFCiviCRM\webhook_alerts', 10, 4);
+add_action('gform_webhooks_post_request', 'GFCiviCRM\webhook_alerts', 10, 4);
 
 /**
  * Save the webhook request to the Entry.
@@ -1105,101 +1155,134 @@ add_action( 'gform_webhooks_post_request', 'GFCiviCRM\webhook_alerts', 10, 4);
  * Request URL is processed before request args. We'll use both filters to build the request
  * data. Supports multiple feeds.
  */
-add_filter( 'gform_webhooks_request_url', function($request_url, $feed, $entry, $form) {
-	// Add the webhook request to the entry meta
-	$current_request = gform_get_meta( $entry['id'], 'webhook_feed_request' );
-	if ( $current_request ) {
-		if ( ! is_array( $current_request ) ) {
-			$current_request = [$feed['id'] => [
-				'request_url' => $request_url
-			]];
-		} else {
-			$current_request[$feed['id']] = [
-				'request_url' => $request_url
-			];
-		}
-	}
-	gform_update_meta( $entry['id'], 'webhook_feed_request', $current_request );
-	return $request_url;
-}, 10, 4);
+add_filter(
+  'gform_webhooks_request_url',
+  function ($request_url, $feed, $entry, $form) {
+    // Add the webhook request to the entry meta
+    $current_request = gform_get_meta($entry['id'], 'webhook_feed_request');
+    if ($current_request) {
+      if (! is_array($current_request)) {
+        $current_request = array(
+          $feed['id'] => array(
+            'request_url' => $request_url,
+          ),
+        );
+      } else {
+        $current_request[$feed['id']] = array(
+          'request_url' => $request_url,
+        );
+      }
+    } else {
+      $current_request = array(
+        $feed['id'] => array(
+          'request_url' => $request_url,
+        ),
+      );
+    }
+    gform_update_meta($entry['id'], 'webhook_feed_request', $current_request);
+    return $request_url;
+  },
+  10,
+  4
+);
 
-add_filter( 'gform_webhooks_request_args', function($request_args, $feed, $entry, $form) {
-	// Add the webhook request to the entry meta
-	$current_request = gform_get_meta( $entry['id'], 'webhook_feed_request' );
-	if ( ! is_array( $current_request ) ) {
-		$current_request = [$feed['id'] => ['request_url' => $current_request]];
-	}
-	$current_request[$feed['id']] = [
-		'request_url' => $current_request[$feed['id']]['request_url'] ?? '',
-		'request_args' => $request_args
-	];
-	gform_update_meta( $entry['id'], 'webhook_feed_request', $current_request );
-	return $request_args;
-}, 10, 4);
+add_filter(
+  'gform_webhooks_request_args',
+  function ($request_args, $feed, $entry, $form) {
+    // Ensure that other WordPress plugins have not lowered the curl timeout which impacts Gravity Forms webhook requests.
+    // Set timeout to 10 seconds
+    $request_args['timeout'] = 10000;
+
+    // Add the webhook request to the entry meta
+    $current_request = gform_get_meta($entry['id'], 'webhook_feed_request');
+    if (! is_array($current_request)) {
+      $current_request = array($feed['id'] => array('request_url' => $current_request));
+    }
+    $current_request[$feed['id']] = array(
+      'request_url'  => $current_request[$feed['id']]['request_url'] ?? '',
+      'request_args' => $request_args,
+    );
+    gform_update_meta($entry['id'], 'webhook_feed_request', $current_request);
+    return $request_args;
+  },
+  10,
+  4
+);
 
 /**
  * Register custom Entry meta fields.
  */
-add_filter( 'gform_entry_meta', function( $entry_meta, $form_id ) {
-    $entry_meta['webhook_feed_request'] = [
-        'label'       => esc_html__( 'Webhook Request', 'gf-civicrm' ),
-        'is_numeric'  => false,
-        'update_entry_meta_callback' => null, // Optional callback for updating.
-        'filter'      => true, // Enable filtering in the Entries UI
-    ];
-	$entry_meta['webhook_feed_response'] = [
-        'label'       => esc_html__( 'Webhook Response', 'gf-civicrm' ),
-        'is_numeric'  => false,
-        'update_entry_meta_callback' => null,
-        'filter'      => true,
-    ];
+add_filter(
+  'gform_entry_meta',
+  function ($entry_meta, $form_id) {
+    $entry_meta['webhook_feed_request']  = array(
+      'label'                      => esc_html__('Webhook Request', 'gf-civicrm'),
+      'is_numeric'                 => false,
+      'update_entry_meta_callback' => null, // Optional callback for updating.
+      'filter'                     => true, // Enable filtering in the Entries UI
+    );
+    $entry_meta['webhook_feed_response'] = array(
+      'label'                      => esc_html__('Webhook Response', 'gf-civicrm'),
+      'is_numeric'                 => false,
+      'update_entry_meta_callback' => null,
+      'filter'                     => true,
+    );
     return $entry_meta;
-}, 10, 2 );
+  },
+  10,
+  2
+);
 
 /**
  * Display the webhook feed result as a metabox when viewing an entry.
  */
-add_filter( 'gform_entry_detail_meta_boxes', function( $meta_boxes, $entry, $form ) {
+add_filter(
+  'gform_entry_detail_meta_boxes',
+  function ($meta_boxes, $entry, $form) {
     // Add a new meta box for the webhook request.
-    $meta_boxes['webhook_feed_request'] = [
-        'title'    => esc_html__( 'Webhook Request', 'gf-civicrm' ),
-        'callback' => function($args) {
-			display_webhook_meta_box( $args, "webhook_feed_request" );
-		},
-        'context'  => 'normal', // Can be 'normal', 'side', or 'advanced'.
-		'priority' => 'low', // Ensure the meta box appears at the bottom of the section.
-    ];
-	// Add a new meta box for the webhook response.
-	$meta_boxes['webhook_feed_response'] = [
-        'title'    => esc_html__( 'Webhook Response', 'gf-civicrm' ),
-        'callback' => function($args) {
-			display_webhook_meta_box( $args, "webhook_feed_response" );
-		},
-        'context'  => 'normal',
-		'priority' => 'low',
-    ];
+    $meta_boxes['webhook_feed_request'] = array(
+      'title'    => esc_html__('Webhook Request', 'gf-civicrm'),
+      'callback' => function ($args) {
+        display_webhook_meta_box($args, 'webhook_feed_request');
+      },
+      'context'  => 'normal', // Can be 'normal', 'side', or 'advanced'.
+      'priority' => 'low', // Ensure the meta box appears at the bottom of the section.
+    );
+    // Add a new meta box for the webhook response.
+    $meta_boxes['webhook_feed_response'] = array(
+      'title'    => esc_html__('Webhook Response', 'gf-civicrm'),
+      'callback' => function ($args) {
+        display_webhook_meta_box($args, 'webhook_feed_response');
+      },
+      'context'  => 'normal',
+      'priority' => 'low',
+    );
 
     return $meta_boxes;
-}, 10, 3 );
+  },
+  10,
+  3
+);
 
-function display_webhook_meta_box( $args, $meta_key ) {
-	// Don't display if the current user is not an admin.
-	if (!in_array( 'administrator', (array) wp_get_current_user()->roles )) {
-		echo '<p>' . esc_html__( 'You need the administrator role to view this data.', 'gf-civicrm' ) . '</p>';
-		return;
-	}
+function display_webhook_meta_box($args, $meta_key)
+{
+  // Don't display if the current user is not an admin.
+  if (! in_array('administrator', (array) wp_get_current_user()->roles)) {
+    echo '<p>' . esc_html__('You need the administrator role to view this data.', 'gf-civicrm') . '</p>';
+    return;
+  }
 
-    $entry = $args['entry']; // Current entry object.
+  $entry = $args['entry']; // Current entry object.
 
-    // Retrieve the webhook meta data.
-    $meta = rgar( $entry, $meta_key );
+  // Retrieve the webhook meta data.
+  $meta = rgar($entry, $meta_key);
 
-    if ( ! empty( $meta ) && is_array( $meta ) ) {
-        // Display the response code and message.
-        echo '<pre style="text-wrap: auto;">';
-		print_r( $meta );
-		echo '</pre>';
-    } else {
-        echo '<p>' . esc_html__( 'No data available.', 'gf-civicrm' ) . '</p>';
-    }
+  if (! empty($meta) && is_array($meta)) {
+    // Display the response code and message.
+    echo '<pre style="text-wrap: auto;">';
+    print_r($meta);
+    echo '</pre>';
+  } else {
+    echo '<p>' . esc_html__('No data available.', 'gf-civicrm') . '</p>';
+  }
 }

--- a/includes/gf-civicrm-wpcmrf.php
+++ b/includes/gf-civicrm-wpcmrf.php
@@ -3,12 +3,12 @@
 /**
  * Copyright (C) Agileware Pty Ltd
  * Based on original work by Jaap Jansma (email : )
- * 
+ *
  * This code is based on the original work by Jaap Jansma.
  * The original plugin can be found at: https://github.com/civimrf/cf-civicrm-formprocessor
  * Original License: AGPL-3.0
  * Original License URI: https://www.gnu.org/licenses/agpl-3.0.en.html
- * 
+ *
  */
 
 namespace GFCiviCRM;
@@ -60,7 +60,7 @@ function api_wrapper( $profile, $entity, $action, $params, $options=[], $api_ver
 	if ( isset( $result['values'] ) ) {
 		return $result['values'];
 	}
-	
+
 	return $result;
 }
 
@@ -73,7 +73,7 @@ function get_profiles() {
 	if ( is_array( $profiles ) ) {
 	  return $profiles;
 	}
-  
+
 	$profiles = array();
 
 	// Local CiviCRM connection
@@ -89,13 +89,14 @@ function get_profiles() {
 		$profiles[$profile_name] = [
 		  'title' => $profile['label'],
 		  'function' => 'GFCiviCRM\gf_civicrm_wpcmrf_api',
+		  'url' => $profile['url'],
 		  'connector' => $profile['connector'],
 		  'site_key' => $profile['site_key'],
 		  'api_key' => $profile['api_key'],
 		];
 	  }
 	}
-  
+
 	return $profiles;
 }
 
@@ -137,10 +138,10 @@ function gf_civicrm_wpcmrf_api( $profile, $entity, $action, $params, $options = 
 
 	/**
 	 * TODO: Prevent caching of specific error codes.
-	 * 
+	 *
 	 * This is likely something that needs to happen in CMRF plugin.
 	 * See https://github.com/CiviMRF/CMRF_Abstract_Core/issues/24
-	 * 
+	 *
 	 */
 	// If options isn't already set, set it to a default value.
 	$options['cache'] ??= '15 minutes';


### PR DESCRIPTION
Using the `{rest_api_url}` merge tag in the webhook url, will now get replaced with the MCRF profile url when available. I had to switch to the `gform_pre_replace_merge_tags` hook as the WebHooks addon was using this and needed to be able to replace first. Fallback is to leave as is and let the WebHooks replacement pick up if CiviCRM is installed locally.

There was some type casting warnings I saw and tried to add checks for. Some extra formatting changes due to my dev environment.